### PR TITLE
Fix issue with multipart type

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -413,9 +413,6 @@ export default class ApiRequest extends LitElement {
       if (formEl.classList.contains("form-urlencoded")){
         fetchOptions.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=utf-8'
       }
-      else{
-        fetchOptions.headers['Content-Type'] = 'multipart/form-data; charset=utf-8'
-      }
     }
 
     //Body Params (json/xml/text)


### PR DESCRIPTION
Hi,

My backend couldn't process requests when I tried send them from RapiDoc. Backend is based on [Python CGI](https://github.com/python/cpython/blob/3.7/Lib/cgi.py).
I investigated this issue and found a problem [here](https://github.com/mrin9/RapiDoc/blob/13d89f815b73d2bd6d1ef3cbab0661662eb2c4f6/src/components/api-request.js#L417). Request payload contains browser-generated boundary fields, but boundary isn't mentioned in Content-Type header. It confusing my backend.

According to [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) (section 3.7.2) 
> "All multipart types ... MUST include a boundary parameter as part of the media type value"

Then I read [some advices](https://stackoverflow.com/questions/39280438/fetch-missing-boundary-in-multipart-form-data-post). I think that best solution in this case: is not to specify Content-Type at all (only for multipart data, of course).

It works for me. But I checked it only from Chrome.