### PR TITLE
Dereference all JSON references initially

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "main": "rapidoc.js",
   "module": "rapidoc.js",
   "dependencies": {
+    "json-refs": "^3.0.12",
     "json-schema-ref-parser": "^6.1.0",
     "lit-element": "2.0.1",
     "lit-html": "1.0.0",

--- a/src/utils/parse-utils.js
+++ b/src/utils/parse-utils.js
@@ -22,11 +22,11 @@ export default async function ProcessSpec(specUrl, resolveCircularRefs){
   };
   try {
     if (typeof specUrl==="string") {
-      const resolvedSpec = await JsonRefs.resolveRefsAt(specUrl);
+      const resolvedSpec = await JsonRefs.resolveRefsAt(specUrl, {resolveCirculars: resolveCircularRefs==='true'});
       convertedSpec = await converter.convertObj(resolvedSpec.resolved, convertOptions);
     }
     else {
-      const resolvedSpec = await JsonRefs.resolveRefs(specUrl);
+      const resolvedSpec = await JsonRefs.resolveRefs(specUrl, {resolveCirculars: resolveCircularRefs==='true'});
       convertedSpec = await converter.convertObj(resolvedSpec.resolved, convertOptions);
     }
 


### PR DESCRIPTION
I tested an Open API 2.0 document that was very large and has many references and it failed. The `json-refs` module seemed to handle the size and position of the references better.
Signed-off-by: mhailstone <matthew.hailstone@gmail.com>