### PR TITLE
Show server descriptions if they exist

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -221,7 +221,9 @@ export default class RapiDoc extends LitElement {
           ${!this.resolvedSpec.servers || (this.resolvedSpec.servers.length===0)  ?``:html`
             ${this.resolvedSpec.servers.map(server => html`
                 <input type='radio' name='api_server' value='${server.url}' @change="${this.onApiServerChange}" checked style='margin:2px 0 5px 8px'/>
-                ${server.url}<br/>
+                ${server.url}
+                ${server.description ? html`- ${server.description}` : ``}
+                <br/>
               `
             )}
           `}


### PR DESCRIPTION
First off I would like to say I really like this doc renderer. It is both pretty and customizable!

I was evaluating it earlier and I noticed that the server selector doesn't show the descriptions if they exist. So this just adds them in right after the url. Not sure if that is the best way to show them, but I figured I'd give it a try.