### PR TITLE
Set default selection to first server with allowServerSelection

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -780,10 +780,12 @@ export default class RapiDoc extends LitElement {
 
   afterSpecParsedAndValidated(spec) {
     this.resolvedSpec = spec;
-    if (this.serverUrl) {
-      this.selectedServer = this.serverUrl;
-    } else if (this.resolvedSpec && this.resolvedSpec.servers && this.resolvedSpec.servers.length > 0) {
-      this.selectedServer = this.resolvedSpec.servers[0].url;
+    if (!this.selectedServer) {
+      if (this.serverUrl) {
+        this.selectedServer = this.serverUrl;
+      } else if (this.resolvedSpec && this.resolvedSpec.servers && this.resolvedSpec.servers.length > 0) {
+        this.selectedServer = this.resolvedSpec.servers[0].url;
+      }
     }
     if (!this.apiListStyle) {
       this.apiListStyle = 'group-by-tag';

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -780,20 +780,15 @@ export default class RapiDoc extends LitElement {
 
   afterSpecParsedAndValidated(spec) {
     this.resolvedSpec = spec;
-    if (this.allowServerSelection === 'false') {
-      if (this.serverUrl) {
-        this.selectedServer = this.serverUrl;
-      } else if (this.resolvedSpec && this.resolvedSpec.servers && this.resolvedSpec.servers.length > 0) {
-        this.selectedServer = this.resolvedSpec.servers[0].url;
-      }
+    if (this.serverUrl) {
+      this.selectedServer = this.serverUrl;
+    } else if (this.resolvedSpec && this.resolvedSpec.servers && this.resolvedSpec.servers.length > 0) {
+      this.selectedServer = this.resolvedSpec.servers[0].url;
     }
     if (!this.apiListStyle) {
       this.apiListStyle = 'group-by-tag';
     }
     this.requestUpdate();
-    window.setTimeout(() => {
-      this.onApiServerChange();
-    }, 0);
   }
 
   onIntersect(entries) {


### PR DESCRIPTION
This resolves #64 in my environment

With the default of `allow-server-selection` enabled, it is still necessary to set a default value for `selectedServer` so that the first entry in the radio-button list is selected.

There is also no need to call `this.onApiServerChange()` as it's now a no-op when there's no `e` passed in.