### PR TITLE
Show logo when search is hidden

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -448,11 +448,13 @@ export default class RapiDoc extends LitElement {
   navBarTemplate() {
     return html`
       <div class='nav-bar'>
+        <div style="padding:16px 30px 0 16px;">
+          <slot name="nav-logo" class="logo"></slot>
+        </div>
         ${(this.allowSearch === 'false')
           ? ''
           : html`
-            <div style="position:sticky; top:0; display:flex; flex-direction:row; align-items: stretch; padding:16px 30px 16px 16px; background: var(--nav-bg-color);"> 
-              <slot name="nav-logo" class="logo"></slot>
+            <div style="position:sticky; top:0; display:flex; flex-direction:row; align-items: stretch; padding:16px 30px 16px 16px; background: var(--nav-bg-color);">
               <div style="display:flex; flex:1">
                 <input id="nav-bar-search" 
                   style="width:100%; padding-right:20px; color:var(--nav-hover-text-color); border-color:var(--nav-accent-color); background-color:var(--nav-hover-bg-color)" 


### PR DESCRIPTION
Two things - 
1. nav-logo slot is currently hidden when allow-search="false" (search has to be present for logo)
2. logo & search collide on the same line

Before:
<img width="1022" alt="Screenshot 2019-11-14 at 12 39 14" src="https://user-images.githubusercontent.com/2506613/68850906-8ceb6e80-06dd-11ea-8420-ae939947e3e2.png">

Now:
<img width="978" alt="Screenshot 2019-11-14 at 12 43 57" src="https://user-images.githubusercontent.com/2506613/68850919-92e14f80-06dd-11ea-84d7-c6b26bbbd3ea.png">


Used following configuration:
```
<rapi-doc
        id="thedoc"
        spec-url="https://petstore.swagger.io/v2/swagger.json"
        render-style="read"
        schema-style="tree"
        show-header="false"
        theme="light"
>
    <div slot="nav-logo" style="display: flex">
        <img src="https://mrin9.github.io/RapiDoc/images/logo.png">
        <h1 style="margin-left:10px;">RapiDoc</h1>
    </div>
</rapi-doc>
```