### PR TITLE
Fix curl headers

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -655,7 +655,7 @@ export default class ApiRequest extends LitElement {
     headerParamEls.map((el) => {
       if (el.value) {
         fetchOptions.headers[el.dataset.pname] = el.value;
-        curlHeaders += ` -H "${fetchOptions.headers[el.dataset.pname]}: ${el.value}"`;
+        curlHeaders += ` -H "${el.dataset.pname}: ${el.value}"`;
       }
     });
     // Add Authentication Header if provided


### PR DESCRIPTION
Currently, for custom request headers RapiDoc will display `-H "value: value"` for curl command.
With this fix it will correctly set it to `-H "name: value"`.