### PR TITLE
do not add "http(s)://servername" if API host starts with "//..."

### DIFF
--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -92,7 +92,7 @@ export default async function ProcessSpec(specUrl, sortTags = false, sortEndpoin
   if (jsonParsedSpec.servers) {
     jsonParsedSpec.servers.forEach((v) => {
       let computedUrl = v.url.trim().toLowerCase();
-      if (!(computedUrl.startsWith('http') || computedUrl.startsWith('{'))) {
+      if (!(computedUrl.startsWith('http') || computedUrl.startsWith('//') || computedUrl.startsWith('{'))) {
         if (window.location.origin.startsWith('http')) {
           v.url = window.location.origin + v.url;
           computedUrl = v.url;


### PR DESCRIPTION
attempted fix for #125