### PR TITLE
Remove Horizontal Padding of Code Blocks

### DIFF
--- a/src/styles/font-styles.js
+++ b/src/styles/font-styles.js
@@ -94,7 +94,7 @@ export default html`
   .m-markdown-small code,
   .m-markdown code {
     background-color: var(--bg3);
-    padding: 1px 6px;
+    padding: 1px;
     border-radius: 2px;
     color: var(--red);
     font-size: calc(var(--font-size-mono) - 1px);


### PR DESCRIPTION
As per #161, the previous padding caused the beginning and end of a multi-line code block to be indented.  This incorrectly implied to users that a preceding or trailing space was present in-code.  This change reduces the size of the padding to eliminate this misperception.