### PR TITLE
allow multiple oauth2 types

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -44,11 +44,14 @@ export default class ApiRequest extends LitElement {
       responseStatus: { type: String, attribute: false },
       responseUrl: { type: String, attribute: false },
       allowTry: { type: String, attribute: 'allow-try' },
+      allowAuthenticationSeperatedCalls: { type: String, attribute: 'allow-authentication-separated-calls' },
       renderStyle: { type: String, attribute: 'render-style' },
       schemaStyle: { type: String, attribute: 'schema-style' },
       activeSchemaTab: { type: String, attribute: 'active-schema-tab' },
       schemaExpandLevel: { type: Number, attribute: 'schema-expand-level' },
       schemaDescriptionExpanded: { type: String, attribute: 'schema-description-expanded' },
+      security: { type: Array },
+      showOperationRequirements: { type: String, attribute: 'show-operation-requirements' },
       activeResponseTab: { type: String }, // internal tracking of response-tab not exposed as a attribute
     };
   }
@@ -525,26 +528,48 @@ export default class ApiRequest extends LitElement {
       `;
     }
 
+    // better handling of custom options from html?
+    const allowSeperatedCalls = (this.allowAuthenticationSeperatedCalls === 'true');
+    const showOpReq = (this.showOperationRequirements === 'true');
+
     return html`
-    <div style="display:flex; align-items: center; margin:16px 0; font-size:var(--font-size-small);">
+    <div style="margin:16px 0; font-size:var(--font-size-small);">
       <div style="display:flex; flex-direction:column; margin:0; width:calc(100% - 60px);">
+        
         <div style="display:flex; flex-direction:row; align-items:center; overflow:hidden;"> 
           ${selectedServerHtml}
         </div>
-        <div style="display:flex;">
-          <div style="padding-right:5px;">Authentication: </div>
-          ${this.api_keys.length > 0
-            ? html`<div style="font-weight:bold;color:var(--blue); overflow:hidden;"> 
-                ${this.api_keys.length === 1
-                  ? `API Key '${this.api_keys[0].name}' in ${this.api_keys[0].in}`
-                  : `${this.api_keys.length} API keys applied`
-                } 
-              </div>`
-            : html`<div style="font-weight:bold; color:var(--red)">No API key applied</div>`
-          }
-        </div>
+
+        ${showOpReq && this.security && this.security.length > 0 ? html`<div class="row" style="font-size:var(--font-size-small); margin:5px 0">
+            <div style="font-weight:bold;padding-right:5px;align-self: flex-start;">Required Security: </div>
+            <div>${this.security.map((securityDictionary) => {
+            const security = [];
+            Object.keys(securityDictionary).forEach((key) => {
+                security.push(html`<div><code>'${key}'</code> with scopes <code>'${securityDictionary[key]}'</code></div>`);
+            });
+            return security;
+          })}</div>
+        </div>` : ''}
       </div>
-      <button class="m-btn primary try-btn" style="padding: 6px 0px;width:60px; align-self:flex-start; margin:1px 0 0 5px;" @click="${this.onTryClick}">TRY</button>
+
+      ${this.api_keys.length > 0 && !allowSeperatedCalls ? html`<div class="row" style="margin:5px 0">
+        <div><span style="font-weight:bold">${this.api_keys.length} API keys applied</span></div>
+        <div style="flex:1"></div>
+        <div style="text-align: right;"><button class="m-btn secodary try-btn" style="padding: 6px 0px;width:60px" @click="${(e) => this.onTryClick(e, null, true)}">TRY</button></div>
+      </div>` : ''}
+
+      ${this.api_keys.length > 0 && allowSeperatedCalls ? this.api_keys.map((v) => html`<div class="row" style="margin:5px 0">
+        <div><span style="font-weight:bold">${v.apiKeyId}</span></div>
+        <div style="flex:1"></div>
+        <div style="text-align: right;"><button class="m-btn secodary try-btn" style="padding: 6px 0px;width:60px" @click="${(e) => this.onTryClick(e, v, false)}">TRY</button></div>
+      </div>`) : ''}
+
+      <div class="row" style="margin:5px 0">
+          <div>No Authentication</div>
+          <div style="flex:1"></div>
+          <div style="text-align: right;"><button class="m-btn primary try-btn" style="padding: 6px 0px;width:60px" @click="${(e) => this.onTryClick(e, null, false)}">TRY</button></div>
+      </div>
+
     </div>
     ${this.responseMessage === ''
       ? ''
@@ -596,7 +621,7 @@ export default class ApiRequest extends LitElement {
     });
   }
 
-  async onTryClick(e) {
+  async onTryClick(e, securitySchema, useAllApiKeys) {
     const me = this;
     const tryBtnEl = e.target;
     let fetchUrl;
@@ -692,11 +717,16 @@ export default class ApiRequest extends LitElement {
 
 
     // Add authentication Query-Param if provided
-    this.api_keys
-      .filter((v) => (v.in === 'query'))
-      .forEach((v) => {
-        fetchUrl = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${v.name}=${encodeURIComponent(v.finalKeyValue)}`;
-      });
+    if (securitySchema != null && securitySchema.in === 'query') {
+      fetchUrl = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${securitySchema.name}=${encodeURIComponent(securitySchema.finalKeyValue)}`;
+    }
+    if (useAllApiKeys) {
+      this.api_keys
+        .filter((v) => (v.in === 'query'))
+        .forEach((v) => {
+          fetchUrl = `${fetchUrl}${fetchUrl.includes('?') ? '&' : '?'}${v.name}=${encodeURIComponent(v.finalKeyValue)}`;
+        });
+    }
 
     // Final URL for API call
     fetchUrl = `${this.serverUrl.replace(/\/$/, '')}${fetchUrl}`;
@@ -720,13 +750,20 @@ export default class ApiRequest extends LitElement {
         curlHeaders += ` -H "${el.dataset.pname}: ${el.value}"`;
       }
     });
+
     // Add Authentication Header if provided
-    this.api_keys
-      .filter((v) => (v.in === 'header'))
-      .forEach((v) => {
-        fetchOptions.headers[v.name] = v.finalKeyValue;
-        curlHeaders += ` -H "${v.name}: ${v.finalKeyValue}"`;
-      });
+    if (securitySchema && securitySchema.in === 'header') {
+      fetchOptions.headers[securitySchema.name] = securitySchema.finalKeyValue;
+      curlHeaders += ` -H "${securitySchema.name}: ${securitySchema.finalKeyValue}"`;
+    }
+    if (useAllApiKeys) {
+      this.api_keys
+        .filter((v) => (v.in === 'header'))
+        .forEach((v) => {
+          fetchOptions.headers[v.name] = v.finalKeyValue;
+          curlHeaders += ` -H "${v.name}: ${v.finalKeyValue}"`;
+        });
+    }
 
     // Submit Form Params (url-encoded or form-data)
     if (formParamEls.length >= 1) {
@@ -857,10 +894,12 @@ export default class ApiRequest extends LitElement {
     try {
       tryBtnEl.disabled = true;
       // await wait(1000);
-      const resp = await fetch(fetchUrl, fetchOptions);
+      const resp = await fetch(fetchUrl, fetchOptions).catch(() => {
+        // need to catch, somehow parent try,catch doesn't work else for cors.
+      });
       tryBtnEl.disabled = false;
       me.responseStatus = resp.ok ? 'success' : 'error';
-      me.responseMessage = `${resp.statusText}:${resp.status}`;
+      me.responseMessage = `${resp.statusText}: ${resp.status}`;
       me.responseUrl = resp.url;
       resp.headers.forEach((hdrVal, hdr) => {
         me.responseHeaders = `${me.responseHeaders}${hdr.trim()}: ${hdrVal}\n`;

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -60,7 +60,10 @@ export default class RapiDoc extends LitElement {
       // Hide/Show Sections & Enable Disable actions
       showHeader: { type: String, attribute: 'show-header' },
       showInfo: { type: String, attribute: 'show-info' },
+      hideAuthenticationRedirectInfo: { type: Boolean, attribute: 'hide-authentication-redirect-info' },
+      showOperationRequirements: { type: String, attribute: 'show-operation-requirements' },
       allowAuthentication: { type: String, attribute: 'allow-authentication' },
+      allowAuthenticationSeperatedCalls: { type: String, attribute: 'allow-authentication-separated-calls' },
       allowTry: { type: String, attribute: 'allow-try' },
       allowSpecUrlLoad: { type: String, attribute: 'allow-spec-url-load' },
       allowSpecFileLoad: { type: String, attribute: 'allow-spec-file-load' },
@@ -559,15 +562,15 @@ export default class RapiDoc extends LitElement {
   }
 
   securitySchemeTemplate() {
-    return securitySchemeTemplate.call(this);
+    return securitySchemeTemplate.call(this, this.hideAuthenticationRedirectInfo);
   }
 
   expandedEndpointTemplate() {
-    return expandedEndpointTemplate.call(this);
+    return expandedEndpointTemplate.call(this, this.allowAuthenticationSeperatedCalls, this.showOperationRequirements);
   }
 
   endpointTemplate() {
-    return endpointTemplate.call(this);
+    return endpointTemplate.call(this, this.allowAuthenticationSeperatedCalls, this.showOperationRequirements);
   }
 
   /* eslint-enable indent */

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -40,7 +40,7 @@ function endpointHeadTemplate(path) {
   `;
 }
 
-function endpointBodyTemplate(path) {
+function endpointBodyTemplate(path, allowAuthenticationSeperatedCalls, showOperationRequirements) {
   let accept = '';
   for (const respStatus in path.responses) {
     for (const acceptContentType in (path.responses[respStatus].content)) {
@@ -72,14 +72,17 @@ function endpointBodyTemplate(path) {
         .parameters = "${path.parameters}"
         .request_body = "${path.requestBody}"
         .api_keys = "${nonEmptyApiKeys}"
+        .security = "${path.security}" 
         .servers = "${path.servers}" 
         server-url = "${path.servers && path.servers.length > 0 ? path.servers[0].url : this.selectedServer.computedUrl}" 
         active-schema-tab = "${this.defaultSchemaTab}" 
+        allow-authentication-separated-calls = "${allowAuthenticationSeperatedCalls}"
         allow-try = "${this.allowTry}"
         accept = "${accept}"
         schema-style = "${this.schemaStyle}" 
         schema-expand-level = "${this.schemaExpandLevel}"
         schema-description-expanded = "${this.schemaDescriptionExpanded}"
+        show-operation-requirements = "${showOperationRequirements}"
       > 
         ${path.callbacks ? callbackTemplate.call(this, path.callbacks) : ''}
       </api-request>
@@ -95,7 +98,7 @@ function endpointBodyTemplate(path) {
   </div>`;
 }
 
-export default function endpointTemplate() {
+export default function endpointTemplate(allowAuthenticationSeperatedCalls, showOperationRequirements) {
   return html`
     ${this.resolvedSpec.tags.map((tag) => html`
     <div class='regular-font section-gap'> 
@@ -116,7 +119,7 @@ export default function endpointTemplate() {
     }).map((path) => html`
       <div id='${path.method}-${path.path.replace(/[\s#:?&=]/g, '-')}' class='m-endpoint regular-font ${path.method} ${path.expanded ? 'expanded' : 'collapsed'}'>
         ${endpointHeadTemplate.call(this, path)}      
-        ${path.expanded ? endpointBodyTemplate.call(this, path) : ''}
+        ${path.expanded ? endpointBodyTemplate.call(this, path, allowAuthenticationSeperatedCalls, showOperationRequirements) : ''}
       </div>
     `)
     }`)

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -31,6 +31,7 @@ export function callbackTemplate(callbacks) {
                       .parameters = "${method[1].parameters}" 
                       .request_body = "${method[1].requestBody}"
                       allow-try = "false"
+                      allow-authentication-separated-calls = "${this.allowAuthenticationSeperatedCalls}"
                       render-style="${this.renderStyle}" 
                       schema-style = "${this.schemaStyle}"
                       active-schema-tab = "${this.defaultSchemaTab}"
@@ -58,7 +59,7 @@ export function callbackTemplate(callbacks) {
   `;
 }
 
-function endpointBodyTemplate(path) {
+function endpointBodyTemplate(path, allowAuthenticationSeperatedCalls, showOperationRequirements) {
   let accept = '';
   for (const respStatus in path.responses) {
     for (const acceptContentType in (path.responses[respStatus].content)) {
@@ -100,15 +101,18 @@ function endpointBodyTemplate(path) {
         .parameters = "${path.parameters}" 
         .request_body = "${path.requestBody}"
         .api_keys = "${nonEmptyApiKeys}"
+        .security = "${path.security}" 
         .servers = "${path.servers}" 
         server-url = "${path.servers && path.servers.length > 0 ? path.servers[0].url : this.selectedServer.computedUrl}" 
         allow-try = "${this.allowTry}"
+        allow-authentication-separated-calls = "${allowAuthenticationSeperatedCalls}"
         accept = "${accept}"
         render-style="${this.renderStyle}" 
         schema-style = "${this.schemaStyle}"
         active-schema-tab = "${this.defaultSchemaTab}"
         schema-expand-level = "${this.schemaExpandLevel}"
         schema-description-expanded = "${this.schemaDescriptionExpanded}"
+        show-operation-requirements = "${showOperationRequirements}"
       > </api-request>
 
       ${path.callbacks ? callbackTemplate.call(this, path.callbacks) : ''}
@@ -127,7 +131,7 @@ function endpointBodyTemplate(path) {
   `;
 }
 
-export default function expandedEndpointTemplate() {
+export default function expandedEndpointTemplate(allowAuthenticationSeperatedCalls, showOperationRequirements) {
   return html`
   ${this.resolvedSpec.tags.map((tag) => html`
     <div id="${tag.name.replace(/[\s#:?&=]/g, '-')}" class='regular-font section-gap--read-mode observe-me' style="border-top:1px solid var(--primary-color);">
@@ -137,7 +141,7 @@ export default function expandedEndpointTemplate() {
       </div>
     </div>
     <div class='regular-font section-gap--read-mode'>
-      ${tag.paths.map((path) => endpointBodyTemplate.call(this, path))}
+      ${tag.paths.map((path) => endpointBodyTemplate.call(this, path, allowAuthenticationSeperatedCalls, showOperationRequirements))}
     </div>
     `)
   }

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -259,38 +259,10 @@ function onInvokeOAuth(apiKeyId, flowType, authFlow, e) {
       console.warn('RapiDoc: Error while receving data');
       return;
     }
-    // client_id, client_secret,redirectUrl
     if (ev.data) {
       callback({
         ...ev.data, isValid, clientId, clientSecret, tokenUrl, redirectUrl: authFlow.redirectUrl,
       });
-      /*
-      if (ev.data.responseType === 'code') {
-        console.log(`RapiDoc: AUTH CODE RECEIVED - ${ev.data.code}`);
-        // return res(ev.data.code);
-        const formData = new FormData();
-        formData.append('grant_type', 'authorization_code');
-        formData.append('code', ev.data.code);
-        formData.append('client_id', clientId);
-        formData.append('client_secret', clientSecret);
-        formData.append('redirect_uri', receiveUrlObj.toString());
-        try {
-          const resp = await fetch(tokenUrl, { method: 'POST', body: formData });
-          console.log(`OAUth Token Response Status: ${resp.statusText}:${resp.status}`);
-          const respObj = await resp.json();
-          console.log('Access Token Response: %o', respObj);
-          if (respObj.access_token) {
-            securityObj.finalKeyValue = `${respObj.token_type} ${respObj.access_token}`;
-            this.requestUpdate();
-          }
-        } catch (err) {
-          console.error('RapiDoc: Unable to get access token');
-        }
-      } else if (ev.data.responseType === 'token') {
-        securityObj.finalKeyValue = `${ev.data.token_type} ${ev.data.access_token}`;
-        this.requestUpdate();
-      }
-      */
     }
   };
   window.addEventListener('message', handleMessageEventFn, true);

--- a/src/utils/security-actions.js
+++ b/src/utils/security-actions.js
@@ -1,0 +1,200 @@
+export const buildFormData = (data) => {
+  const params = new URLSearchParams();
+  for (const name in data) {
+    const value = data[name];
+    if (value !== undefined && value !== '') {
+      params.set(name, value);
+    }
+  }
+  return params.toString();
+};
+
+const authorizeRequest = (payload) => {
+  const {
+    url,
+    body,
+    query = {},
+    headers = {},
+    additionalQueryStringParams,
+  } = payload;
+
+  const parsedUrl = new URL(url);
+  if (typeof additionalQueryStringParams === 'object') {
+    parsedUrl.query = { ...parsedUrl.query, ...additionalQueryStringParams, ...query };
+  }
+
+  const fetchUrl = parsedUrl.toString();
+
+  const headersExpanded = {
+    Accept: 'application/json',
+    'Content-Type': 'application/x-www-form-urlencoded',
+    'X-Requested-With': 'XMLHttpRequest RapiDoc',
+    ...headers,
+  };
+
+  return fetch(fetchUrl, {
+    url: fetchUrl,
+    method: 'post',
+    headers: headersExpanded,
+    body,
+  })
+    .then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+      throw Error(response.statusText);
+    })
+    .then((json) => json)
+    .catch((e) => {
+      const err = new Error(e);
+      let message = err.message;
+      // investigate to check whether there are more details on why the authorization
+      // request failed (according to RFC 6479).
+      if (e.response && e.response.data) {
+        const errData = e.response.data;
+        try {
+          const jsonResponse = typeof errData === 'string' ? JSON.parse(errData) : errData;
+          if (jsonResponse.error) message += `, error: ${jsonResponse.error}`;
+          if (jsonResponse.error_description) message += `, description: ${jsonResponse.error_description}`;
+        } catch (jsonError) {
+          // Ignore
+        }
+      }
+      throw Error(message);
+    });
+};
+
+export const preAuthorizeImplicit = (payload) => {
+  // @todo this is not tested, how should this work?
+  const {
+    token, isValid, flow,
+  } = payload;
+
+  if (flow !== 'accessCode' && !isValid) {
+    throw Error("Authorization may be unsafe, passed state was changed in server Passed state wasn't returned from auth server");
+  }
+
+  if (token.error) {
+    throw Error(JSON.stringify(payload));
+  }
+
+  // are we done here and return value? token?
+  return 'crash';
+};
+
+export const authorizePassword = (authConfigs) => {
+  // @todo, not tested yet
+  const {
+    scope,
+    username,
+    password,
+    passwordType,
+    clientId,
+    clientSecret,
+    tokenUrl,
+  } = authConfigs;
+
+  let form = {
+    grant_type: 'password',
+    scope,
+    username,
+    password,
+  };
+  const query = {};
+  const headers = {};
+
+  switch (passwordType) {
+    case 'request-body':
+      if (clientId) {
+        form = Object.assign(form, { client_id: clientId });
+      }
+      if (clientSecret) {
+        form = Object.assign(form, { client_secret: clientSecret });
+      }
+      break;
+
+    case 'basic':
+      headers.Authorization = `Basic ${btoa(`${clientId}:${clientSecret}`)}`;
+      break;
+
+    default:
+      throw new Error(`Invalid passwordType ${passwordType} was passed, not including client id and secret`);
+  }
+
+  return authorizeRequest({
+    body: buildFormData(form),
+    url: tokenUrl,
+    headers,
+    query,
+  });
+};
+
+
+export const authorizeApplication = (authConfigs) => {
+  const {
+    scope,
+    clientId,
+    clientSecret,
+    tokenUrl,
+  } = authConfigs;
+
+  const headers = {
+    Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+  };
+
+  const form = {
+    grant_type: 'client_credentials',
+    scope,
+  };
+
+  return authorizeRequest({
+    body: buildFormData(form),
+    url: tokenUrl,
+    headers,
+  });
+};
+
+
+export const authorizeAccessCodeWithFormParams = (payload) => {
+  const {
+    clientId, clientSecret, redirectUrl, code, tokenUrl,
+  } = payload;
+
+  const form = {
+    grant_type: 'authorization_code',
+    code,
+    client_id: clientId,
+    client_secret: clientSecret,
+    redirect_uri: redirectUrl,
+    // code_verifier: codeVerifier, we dont have this until crypto library or other
+  };
+
+  return authorizeRequest({
+    body: buildFormData(form),
+    url: tokenUrl,
+  });
+};
+
+export const authorizeAccessCodeWithBasicAuthentication = (payload) => {
+  // @todo this is not tested
+  const {
+    clientId, clientSecret, redirectUrl, code, tokenUrl,
+  } = payload;
+
+  const headers = {
+    Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+  };
+
+  const form = {
+    grant_type: 'authorization_code',
+    code,
+    client_id: clientId,
+    redirect_uri: redirectUrl,
+  };
+
+  return authorizeRequest({
+    body: buildFormData(form),
+    url: tokenUrl,
+    headers,
+  });
+};


### PR DESCRIPTION
Lets try this again then.

built on top of 2 PR https://github.com/mrin9/RapiDoc/pull/154 and https://github.com/mrin9/RapiDoc/pull/151

I've started a new branch from master and moved my old PR code into this. Adjusting after feedback from previous PRs.

I don't understand how to easy populate subclasses with settings from html, that can be a little messy.

Solves OAuth2 security with multiple different schemas.

Tested oauth on real sever

- clientCredentials
- authorizationCode

Prepared but not tested (don't have oauth configuration server). I've placed code and @todo tags pointing to where to look and test.

- implicit
- application
- password
- using pkce (needs to create hashes e.g. crypto library)

Features

- Support for multiple flows in same security scheme
- operation lists required scopes
- scope selection when requesting tokens
- using new oauth-receiver html file
- turn on/off feature thru 'api'

```
hide redirect information (only needed for configure developer, not everyone else when done)
    hide-authentication-redirect-info="true" 

show needed security requirements on each operation (scopes)
    show-operation-requirements="true" 

seperate calls based on security. When using different security clients/scopes on calls. make it possible to call with correct scheme
    allow-authentication-separated-calls
```