### PR TITLE
add token to spec load

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -841,8 +841,15 @@ export default class RapiDoc extends LitElement {
     this.matchPaths = '';
   }
 
+  async refreshSpecWithToken(apiKeyId, msgEvent) {
+    await this.loadSpec(this.specUrl, msgEvent.data.access_token);
+    const securityObj = this.resolvedSpec.securitySchemes.find((v) => (v.apiKeyId === apiKeyId));
+    securityObj.finalKeyValue = `Bearer ${msgEvent.data.access_token}`;
+    this.requestUpdate();
+  }
+
   // Public Method
-  async loadSpec(specUrl) {
+  async loadSpec(specUrl, token) {
     if (!specUrl) {
       return;
     }
@@ -859,6 +866,7 @@ export default class RapiDoc extends LitElement {
         this.getAttribute('api-key-location'),
         this.getAttribute('api-key-value'),
         this.getAttribute('server-url'),
+        token,
       );
       this.loading = false;
       if (spec === undefined || spec === null) {

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -99,8 +99,8 @@ async function onWindowMessageEvent(msgEvent, winObj, tokenUrl, clientId, client
       // Authorization Code flow
       fetchAccessToken.call(this, tokenUrl, clientId, clientSecret, redirectUrl, grantType, msgEvent.data.code, apiKeyId, authFlowDivEl);
     } else if (msgEvent.data.responseType === 'token') {
-      // Implicit flow
-      updateOAuthKey.call(this, apiKeyId, msgEvent.data.token_type, msgEvent.data.access_token);
+      // Implicit
+      await this.refreshSpecWithToken(apiKeyId, msgEvent);
     }
   }
 }
@@ -285,7 +285,7 @@ export default function securitySchemeTemplate() {
         ? html`
           <div class="blue-text"> ${providedApiKeys.length} API key applied </div>
           <div style="flex:1"></div>
-          <button class="m-btn thin-border" @click=${() => { onClearAllApiKeys.call(this); }}>CLEAR ALL API KEYS</button>`
+          <button class="m-btn thin-border" @click=${() => { onClearAllApiKeys.call(this); this.loadSpec(this.specUrl); }}>CLEAR ALL API KEYS</button>`
         : html`<div class="red-text">No API key applied</div>`
       }
     </div>
@@ -300,7 +300,7 @@ export default function securitySchemeTemplate() {
                   ${v.finalKeyValue
                     ? html`
                       <span class='blue-text'>  ${v.finalKeyValue ? 'Key Applied' : ''} </span> 
-                      <button class="m-btn thin-border small" @click=${() => { v.finalKeyValue = ''; this.requestUpdate(); }}>REMOVE</button>
+                      <button class="m-btn thin-border small" @click=${() => { v.finalKeyValue = ''; this.requestUpdate(); this.loadSpec(this.specUrl); }}>REMOVE</button>
                       `
                     : ''
                   }

--- a/src/utils/spec-parser.js
+++ b/src/utils/spec-parser.js
@@ -5,13 +5,14 @@ import Swagger from 'swagger-client';
 import marked from 'marked';
 import { invalidCharsRegEx } from '@/utils/common-utils';
 
-export default async function ProcessSpec(specUrl, sortTags = false, sortEndpointsBy, attrApiKey = '', attrApiKeyLocation = '', attrApiKeyValue = '', serverUrl = '') {
+export default async function ProcessSpec(specUrl, sortTags = false, sortEndpointsBy, attrApiKey = '', attrApiKeyLocation = '', attrApiKeyValue = '', serverUrl = '', token) {
   let jsonParsedSpec;
   let convertedSpec;
   // let resolvedRefSpec;
   // let resolveOptions;
   // const specLocation = '';
   // let url;
+  console.log(`Key Value: ${attrApiKeyValue}`);
 
   const convertOptions = {
     patch: true,
@@ -22,7 +23,14 @@ export default async function ProcessSpec(specUrl, sortTags = false, sortEndpoin
   try {
     let specObj;
     if (typeof specUrl === 'string') {
-      specObj = await Swagger(specUrl);
+      specObj = await Swagger({
+        url: specUrl,
+        requestInterceptor: (req) => {
+          if (!req.headers.Authorization && token) {
+            req.headers.Authorization = `Bearer ${token}`;
+          }
+        },
+      });
     } else {
       specObj = await Swagger({ spec: specUrl });
     }


### PR DESCRIPTION
I modified the loadSpec to send a token with the request so the swagger json can be filtered based on what a user has permission to in the api.  i was wondering what the use case is for multiple tokens and if this is something you would be interested in for the mainline.

thanks.

-Eric