### PR TITLE
Fix trailing semicolon in 'Content-Type' header

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -867,7 +867,7 @@ export default class ApiRequest extends LitElement {
       // Common for all request-body
       if (!requestBodyType.includes('form-data')) {
         // For multipart/form-data dont set the content-type to allow creation of browser generated part boundaries
-        fetchOptions.headers['Content-Type'] = `${requestBodyType}; charset=utf-8;`;
+        fetchOptions.headers['Content-Type'] = `${requestBodyType}; charset=utf-8`;
       }
       curlHeaders += ` -H "Content-Type: ${requestBodyType}" \\ \n`;
     }


### PR DESCRIPTION
Trailing semicolon in `Content-Type` header is invalid. 

`express.js` fails to parse request body sent with such a header.