### PR TITLE
fix wrong attribute name in docs

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -298,7 +298,7 @@
             <td>true</td>
           </tr>
           <tr>
-            <td class="attr-col mono bold right">add-info-headings-to-navbar</td>
+            <td class="attr-col mono bold right">info-description-headings-in-navbar</td>
             <td class="gray">
               Include headers from info -> description section to the Navigation bar (applies to read mode only)
               <br/>


### PR DESCRIPTION
There is an error in api page: `info-description-headings-in-navbar` instead of `add-info-headings-to-navbar`