### PR TITLE
Remove implicit scroll during on intersect with observable items

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -416,7 +416,6 @@ export default class RapiDoc extends LitElement {
         // Add active class in the new element
         if (newNavEl) {
           window.history.replaceState(null, null, `${window.location.href.split('#')[0]}#${entry.target.id}`);
-          newNavEl.scrollIntoView({ behavior: 'auto', block: 'center' });
           newNavEl.classList.add('active');
         }
         // Remove active class from previous element


### PR DESCRIPTION
Hi,

Our team started to use RapiDoc for our developer portal and we are really excited with getting results.
We plan to embed RapiDoc in the read mode as a page of our portal.

But, I run into a problem. If I wrap `<rapi-doc>` with any html tag, then scroll doesn't work. For example
``` html
<html>
  <body>
    <script src="js/rapidoc-min.js"></script>
    <div>
      <rapi-doc spec-url="openapi.yaml" render-style="read"></rapi-doc>
    </div>
  </body>
</html>
```
I've reproduced this problem in Chrome 83 and Firefox 76.

After some research I find out that problem in `onIntersect` method which calls `scrollIntoView` on intersected element.
It looks redundant, because if `onIntersect` is called, it means that the element is already visible and it's don't require scrolling to it.
I just remove `scrollIntoView` and the scroll starts to work correctly.

Can you take a look at my PR, please?

Thanks.
