### PR TITLE
fix Content-Type header to be according to IANA and RFC

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -968,8 +968,17 @@ export default class ApiRequest extends LitElement {
       // Common for all request-body
       if (!requestBodyType.includes('form-data')) {
         // For multipart/form-data dont set the content-type to allow creation of browser generated part boundaries
-        fetchOptions.headers['Content-Type'] = `${requestBodyType}; charset=utf-8`;
+        switch (requestBodyType) {
+          // https://www.iana.org/assignments/media-types/application/json
+          case "application/json":
+            fetchOptions.headers['Content-Type'] = "application/json";
+            break;
+          default:
+            fetchOptions.headers['Content-Type'] = `${requestBodyType}; charset=utf-8`;
+            break;
+        }
       }
+      
       curlHeaders += ` -H "Content-Type: ${requestBodyType}" \\\n`;
     }
 


### PR DESCRIPTION
We use expressjs and the body parser is implemented in a strict way. RapiDoc is always adding charset: utf-8 even though this is non-standard and not according to the IANA-Definition. 

This PR changes the api-request.js file. If the Content-Type is application/json and uses only that as for the header. If it is not that, it will use the old method. This implementation uses a switch to extend the functionality if there are other use cases. It also provides a comment,which is a link to the official IANA-page, which should enforce the clarity of the line.

See also:
https://github.com/request/request/issues/383