### PR TITLE
Add support for enums in server veriable object

### DIFF
--- a/docs/specs/server.yaml
+++ b/docs/specs/server.yaml
@@ -4,19 +4,23 @@ info:
   title: Server Variables
   description: >
     Various ways to define API servers in the spec including variables
-    
+
     ```yaml
       servers:
         - url: 'http://example.com/api'
           description: Test server (just for example)
         - url: '/api'
-        - url: '{protocol}://dev.com/api'
+        - url: '{protocol}://dev.com/api/{version}'
           variables:
             protocol:
-              default: https          
+              description: Protocol (with enum)
+              default: https
               enum:
                 - http
                 - https
+            version:
+              description: API Version (without enum)
+              default: v1
         - url: '{protocol}://{environment}.example.com/{version}'
           variables:
             environment:
@@ -31,27 +35,31 @@ info:
                 - api.dev  # Development server
                 - api.qa   # Testing server
             protocol:
-              default: https          
+              default: https
               enum:
                 - http
                 - https
             version:
-              default: v2          
+              default: v2
               enum:
                 - v1
                 - v2
-    ```                     
+    ```
 servers:
   - url: 'http://example.com/api'
     description: Test server (just for example)
   - url: '/api'
-  - url: '{protocol}://dev.com/api'
+  - url: '{protocol}://dev.com/api/{version}'
     variables:
       protocol:
-        default: https          
+        description: Protocol (with enum)
+        default: https
         enum:
           - http
           - https
+      version:
+        description: API Version (without enum)
+        default: v1
   - url: '{protocol}://{environment}.example.com/{version}'
     variables:
       environment:
@@ -66,20 +74,20 @@ servers:
           - api.dev  # Development server
           - api.qa   # Testing server
       protocol:
-        default: https          
+        default: https
         enum:
           - http
           - https
       version:
-        default: v2          
+        default: v2
         enum:
           - v1
           - v2
 paths:
   /server-variables:
     get:
-      summary: Server Variable. 
-      discription: Computed server url should be shown against `API SERVER`. 
+      summary: Server Variable.
+      discription: Computed server url should be shown against `API SERVER`.
       responses:
         '200':
           description: successful operation

--- a/src/templates/server-template.js
+++ b/src/templates/server-template.js
@@ -10,7 +10,7 @@ function onApiServerChange(e, server) {
 }
 
 function onApiServerVarChange(e, serverObj) {
-  const inputEls = [...e.currentTarget.closest('table').querySelectorAll('input')];
+  const inputEls = [...e.currentTarget.closest('table').querySelectorAll('input, select')];
   let tempUrl = serverObj.url;
   inputEls.forEach((v) => {
     const regex = new RegExp(`{${v.dataset.var}}`, 'g');
@@ -31,13 +31,34 @@ function serverVarsTemplate() {
         <tr>
           <td style="vertical-align: middle;" >${kv[0]}</td>
           <td>
-            <input 
-              type = "text" 
-              spellcheck = "false" 
+            ${kv[1].enum
+            ? html`
+            <select
+              data-var = "${kv[0]}"
+              @input = ${(e) => { onApiServerVarChange.call(this, e, this.selectedServer); }}
+            >
+            ${Object.entries(kv[1].enum).map((e) => (kv[1].default === e[1]
+              ? html`
+              <option
+                selected
+                label = ${e[1]}
+                value = ${e[1]}
+              />`
+              : html`
+              <option
+                label = ${e[1]}
+                value = ${e[1]}
+              />`
+            ))}
+            </select>`
+            : html`
+            <input
+              type = "text"
+              spellcheck = "false"
               data-var = "${kv[0]}"
               value = "${kv[1].default}"
               @input = ${(e) => { onApiServerVarChange.call(this, e, this.selectedServer); }}
-            />
+            />`}
           </td>
         </tr>
         ${kv[1].description
@@ -59,9 +80,9 @@ export default function serverTemplate() {
         ? ''
         : html`
           ${this.resolvedSpec.servers.map((server) => html`
-            <input type = 'radio' 
-              name = 'api_server' 
-              value = '${server.url}' 
+            <input type = 'radio'
+              name = 'api_server'
+              value = '${server.url}'
               @change = ${(e) => { onApiServerChange.call(this, e, server); }}
               .checked = '${this.selectedServer.url === server.url}'
               style = 'margin:4px 0'


### PR DESCRIPTION
Add support for enums in server variable object.
Variables with an `enum` are rendered as `select` with the `default` option set to `selected`.
Variables without an `enum` are rendered as `input` (like before).
The examples are updated to show the above cases.

Reference: https://swagger.io/specification/#server-variable-object
