### PR TITLE
Make the components link clickable in the nav bar

### DIFF
--- a/src/templates/navbar-template.js
+++ b/src/templates/navbar-template.js
@@ -82,11 +82,11 @@ export default function navbarTemplate() {
     ? ''
     : html`<div id='link-components' class='nav-bar-section' >Components</div>
       ${this.resolvedSpec.components.map((component) => html`
-        <div class='nav-bar-tag' id="link-cmp-${component.name.toLowerCase()}" @click='${(e) => this.scrollToEl(e)}'>
+        <div class='nav-bar-tag' data-content-id='cmp-${component.name.toLowerCase()}' id='link-cmp-${component.name.toLowerCase()}' @click='${(e) => this.scrollToEl(e)}'>
           ${component.name}
         </div>
         ${component.subComponents.map((p) => html`
-        <div class='nav-bar-path' id='link-cmp-${p.id}' @click='${(e) => this.scrollToEl(e)}'> 
+        <div class='nav-bar-path' data-content-id='cmp-${p.id}' id='link-cmp-${p.id}' @click='${(e) => this.scrollToEl(e)}'>
           <span> ${p.name} </span>
         </div>`)}
       `)}


### PR DESCRIPTION
This PR adds the missing `data-content-id` attributes to make the nav bar components links clickable when used with the following config:
```
<rapi-doc 
render-style="read"
show-components="true"
>
```

Thanks!