### PR TITLE
Show navigation item as path

### DIFF
--- a/docs/examples/show-nav-item-as-path.html
+++ b/docs/examples/show-nav-item-as-path.html
@@ -1,0 +1,30 @@
+<!doctype html>
+  <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132775238-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-132775238-1');
+    </script>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600&family=Roboto+Mono&display=swap" rel="stylesheet">
+    <script type="text/javascript" src="../rapidoc-min.js"></script>
+  </head>
+  <body>
+    <rapi-doc 
+      show-info = "true"
+      spec-url = "../specs/petstore_extended.yaml"
+      show-header="false" 
+      render-style="focused"
+      allow-try="false" 
+      regular-font="Open Sans"
+      mono-font = "Roboto Mono"
+      show-nav-item-as="path"
+    > </rapi-doc>
+  </body>
+</html>

--- a/docs/list.html
+++ b/docs/list.html
@@ -227,6 +227,13 @@
     </div>
 
     <div class = "container" >
+      <a href="./examples/show-nav-item-as-path.html">Show Navigation Item As Path</a>
+      <div class = "c-description" >
+        Path / Summary
+      </div>
+    </div>
+
+    <div class = "container" >
       <a href="./examples/markdown-headings.html">Markdown headings in Navigation</a>
       <div class = "c-description">
         Optionally include markdown headings to navigation bar 

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -97,6 +97,7 @@ export default class RapiDoc extends LitElement {
       navHoverTextColor: { type: String, attribute: 'nav-hover-text-color' },
       navAccentColor: { type: String, attribute: 'nav-accent-color' },
       navItemSpacing: { type: String, attribute: 'nav-item-spacing' },
+      showNavItemAs: { type: String, attribute: 'show-nav-item-as' },
       infoDescriptionHeadingsInNavBar: { type: String, attribute: 'info-description-headings-in-navbar' },
 
       // Filters
@@ -352,6 +353,7 @@ export default class RapiDoc extends LitElement {
     if (!this.sortTags || !'true, false,'.includes(`${this.sortTags},`)) { this.sortTags = 'false'; }
     if (!this.sortEndpointsBy || !'method, path,'.includes(`${this.sortEndpointsBy},`)) { this.sortEndpointsBy = 'path'; }
     if (!this.navItemSpacing || !'compact, relaxed, default,'.includes(`${this.navItemSpacing},`)) { this.navItemSpacing = 'default'; }
+    if (!this.showNavItemAs || !'path, summary,'.includes(`${this.showNavItemAs},`)) { this.showNavItemAs = 'summary'; }
     if (!this.fontSize || !'default, large, largest,'.includes(`${this.fontSize},`)) { this.fontSize = 'default'; }
 
     if (!this.showInfo || !'true, false,'.includes(`${this.showInfo},`)) { this.showInfo = 'true'; }

--- a/src/templates/navbar-template.js
+++ b/src/templates/navbar-template.js
@@ -73,7 +73,7 @@ export default function navbarTemplate() {
         return true;
       }).map((p) => html`
       <div class='nav-bar-path' data-content-id='${p.method}-${p.path}' id='link-${p.method}-${p.path.replace(invalidCharsRegEx, '-')}' @click='${(e) => this.scrollToEl(e)}'> 
-        <span style = "${p.deprecated ? 'filter:opacity(0.5)' : ''}"> ${p.summary || p.path} </span>
+        <span style = "${p.deprecated ? 'filter:opacity(0.5)' : ''}"> ${this.showNavItemAs === 'path' ? p.path : p.summary} </span>
       </div>`)}
     `)}
 


### PR DESCRIPTION
This change allows user to show navigation item as path.

Example:

```
<rapi-doc 
      show-info = "true"
      spec-url = "../specs/petstore_extended.yaml"
      show-header="false" 
      render-style="focused"
      allow-try="false" 
      regular-font="Open Sans"
      mono-font = "Roboto Mono"
      show-nav-item-as="path"
    > </rapi-doc>
```