### PR TITLE
Add support for scopes in oauth client_credentials authorization flow

### DIFF
--- a/docs/examples/oauth2-with-scopes.html
+++ b/docs/examples/oauth2-with-scopes.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132775238-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-132775238-1');
+    </script>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600&family=Roboto+Mono&display=swap" rel="stylesheet">
+    <script type="text/javascript" src="../rapidoc-min.js"></script>
+</head>
+<body>
+<rapi-doc spec-url="../specs/oauth2-with-scopes.yaml"
+          show-info = "false"
+          render-style="read"
+          show-header="false"
+          regular-font='Open Sans'
+          mono-font = "Roboto Mono"
+>  </rapi-doc>
+</body>
+</html>

--- a/docs/list.html
+++ b/docs/list.html
@@ -323,6 +323,13 @@
     </div>
 
     <div class = "container">
+      <a href="./examples/oauth2-with-scopes.html.html"> OAuth2 Client Credentials flow with scopes support </a>
+      <div class = "c-description" >
+        Example of an Oauth2 Client Credentials flow, which supports sending scopes.
+      </div>
+    </div>
+
+    <div class = "container">
       <a href="./examples/additional-props.html"> Additional Properties </a>
       <div class = "c-description" >
         Apart from fixed predefined properties, schema can contain additional properties

--- a/docs/specs/oauth2-with-scopes.yaml
+++ b/docs/specs/oauth2-with-scopes.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Petstore API
+  description: Test API which supports scopes for Oauth2 Client Credentials work flow.
+  version: "1.0"
+servers:
+  - url: 'https://exampleurl.org'
+security:
+  - exampleOauth2Flow: []
+paths:
+  '/dogs':
+    get:
+      summary: Return an array of the petstore's dogs.
+      responses:
+        '200':
+          description: A successful request returns an array of dogs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dogs:
+                    type: array
+                    example: "[Rex, Lassie, Beethoven]"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+components:
+  securitySchemes:
+    exampleOauth2Flow:
+      type: oauth2
+      description: >-
+        You authorize requests, by providing client credentials.
+      flows:
+        clientCredentials:
+          tokenUrl: 'http://localhost:8080/token'
+          scopes:
+            doglover: "always required"
+            owner: "optional"

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -45,7 +45,7 @@ function updateOAuthKey(apiKeyId, tokenType = 'Bearer', accessToken) {
 
 /* eslint-disable no-console */
 // Gets Access-Token in exchange of Authorization Code
-async function fetchAccessToken(tokenUrl, clientId, clientSecret, redirectUrl, grantType, authCode, sendClientSecretIn = 'header', apiKeyId, authFlowDivEl) {
+async function fetchAccessToken(tokenUrl, clientId, clientSecret, redirectUrl, grantType, authCode, sendClientSecretIn = 'header', apiKeyId, authFlowDivEl, scopes = null) {
   const respDisplayEl = authFlowDivEl ? authFlowDivEl.querySelector('.oauth-resp-display') : undefined;
   const urlFormParams = new URLSearchParams();
   const headers = new Headers();
@@ -60,6 +60,9 @@ async function fetchAccessToken(tokenUrl, clientId, clientSecret, redirectUrl, g
   } else {
     urlFormParams.append('client_id', clientId);
     urlFormParams.append('client_secret', clientSecret);
+  }
+  if (scopes) {
+    urlFormParams.append('scope', scopes);
   }
 
   try {
@@ -166,7 +169,8 @@ async function onInvokeOAuthFlow(apiKeyId, flowType, authUrl, tokenUrl, e) {
     }, 10);
   } else if (flowType === 'clientCredentials') {
     grantType = 'client_credentials';
-    fetchAccessToken.call(this, tokenUrl, clientId, clientSecret, redirectUrlObj.toString(), grantType, '', sendClientSecretIn, apiKeyId, authFlowDivEl);
+    const selectedScopes = checkedScopeEls.map((v) => v.value).join(' ');
+    fetchAccessToken.call(this, tokenUrl, clientId, clientSecret, redirectUrlObj.toString(), grantType, '', sendClientSecretIn, apiKeyId, authFlowDivEl, selectedScopes);
   }
 }
 /* eslint-enable no-console */


### PR DESCRIPTION
With this commit, the selected scopes are as url form parameters, within the token network request, when client_credentials authorization flow is being used.