### PR TITLE
Update `allow-try` documentation

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -393,9 +393,8 @@
           <tr>
             <td class="mono bold right">allow-try</td>
             <td class="gray">
-              'TRY' feature allows you to make REST calls to the API server. 
-              To disable this feature set it to false<br/>
-              Setting it to false will also hide API-Servers if specified in the spec
+              The 'TRY' feature allows you to make REST calls to the API server. 
+              To disable this feature, set it to false.
             </td>
             <td>true</td>
           </tr>


### PR DESCRIPTION
It no longer controls `allow-server-selection`, since 90631ba20 / #289.