### PR TITLE
Fix example defined on array property being ignored

### DIFF
--- a/docs/specs/examples.yaml
+++ b/docs/specs/examples.yaml
@@ -369,6 +369,18 @@ paths:
                     amount: 700,
                     currency: INR
                   }
+  /object-containg-array-property-with-example:
+    get:
+      summary: Object schema with array type property containing example
+      tags:
+        - Providing Examples
+      responses:
+        200:
+          description: Object with array type property containing example
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ObjectWithArrayPropExample"
 components:
   schemas:
     cost:
@@ -417,3 +429,17 @@ components:
       example:
         name: name-1
         age: 1
+    ObjectWithArrayPropExample:
+      type: object
+      properties:
+        numberProp:
+          type: number
+          example: 1000
+        stringProp:
+          type: string
+          enum: [value0, value1]
+        arrayProp:
+          type: array
+          items:
+            type: number
+          example: [0, 1, 2]

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -266,7 +266,9 @@ export function schemaToSampleObj(schema, config = { }) {
       if (schema.properties[key].readOnly && !config.includeReadOnly) { continue; }
       if (schema.properties[key].writeOnly && !config.includeWriteOnly) { continue; }
       if (schema.properties[key].type === 'array' || schema.properties[key].items) {
-        if (schema.properties[key]?.items?.example) { // schemas and properties support single example but not multiple examples.
+        if (schema.properties[key].example) {
+          obj[key] = schema.properties[key].example;
+        } else if (schema.properties[key]?.items?.example) { // schemas and properties support single example but not multiple examples.
           obj[key] = [schema.properties[key].items.example];
         } else {
           obj[key] = [schemaToSampleObj(schema.properties[key].items, config)];


### PR DESCRIPTION
This PR fixes issue when an example defined directly on `array` type object property was ignored.