### PR TITLE
Hide components under 'focused' template

### DIFF
--- a/src/templates/main-body-template.js
+++ b/src/templates/main-body-template.js
@@ -113,13 +113,17 @@ export default function mainBodyTemplate() {
                   ? this.renderStyle === 'read'
                     ? expandedEndpointTemplate.call(this)
                     : this.renderStyle === 'focused'
-                      ? focusedEndpointTemplate.call(this)
+                      ? this.selectedContentId.startsWith('cmp-')
+                        ? componentsTemplate.call(this)
+                        : focusedEndpointTemplate.call(this)
                       : endpointTemplate.call(this)
                   : ''
                 }
               </div>
 
-              ${this.showComponents === 'true' ? componentsTemplate.call(this) : ''}
+              ${this.showComponents === 'true' && this.renderStyle !== 'focused'
+                  ? componentsTemplate.call(this)
+                  : ''}
             `
             : ''
           }


### PR DESCRIPTION
"Focused" mode is great because it allows you to focus on the docs of a specific operation. However, when "show-components" is "true", all the component docs will appear at the bottom of the page, which looks rather messy.

This PR fixes that and displays the component docs only when a component has been selected.