### PR TITLE
Fix expanding of paths with invalid chars

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -652,7 +652,7 @@ export default class RapiDoc extends LitElement {
       path = pathInput.match(new RegExp('/.*$'));
       const pathValue = (path && path.length === 1) ? path[0] : null;
 
-      if (methodType && pathValue && methodType === v.method && pathValue === v.path) {
+      if (methodType && pathValue && methodType === v.method && pathValue === v.path.replace(invalidCharsRegEx, '-')) {
         this.selectedContentId = `${methodType}-${pathValue}`;
         v.expanded = expandOperation;
         tag.expanded = true;


### PR DESCRIPTION
### Problem 
If you have a link for an endpoint that has a parameter, for example `foo/{id}` it would be `example.com/#get-/foo/-id-`, then in `render-style: view` the links won't expand the endpoint containers. 

### Solution
The invalid chars in the compared path in `expandTreeToPath` should also be replaced with `-`