### PR TITLE
Fix title usage and array rendering in oneOf/anyOf

### DIFF
--- a/docs/specs/oneof-titles.json
+++ b/docs/specs/oneof-titles.json
@@ -43,24 +43,35 @@
                             { "$ref": "#/components/schemas/worker" },
                             {
                                 "type": "object",
-                                "description": "this has no title",
+                                "description": "This has no title",
                                 "properties": {
                                     "personnel number": { "type": "string" }
                                 }
                             },
                             {
                                 "type": "array",
-                                "title": "an array title",
+                                "title": "An array title",
+                                "description": "An array with a title",
                                 "items": { "type": "string", "title": "an array item" }
                             },
                             {
                                 "type": "array",
-                                "description": "array without title",
+                                "description": "An array without a title",
                                 "items": { "type": "string", "title": "an array item" }
                             },
-                            { "type": "string", "title": "ID number" },
-                            { "type": "null" }
+                            { "type": "string", "description": "Primitive with a title", "title": "ID number" },
+                            { "type": "int", "description": "Primitive without a title" },
+                            { "type": "null", "description": "Null with a title", "title": "Null with a title" },
+                            { "type": "null", "description": "Null without a title" }
                         ]
+                    },
+                    "anotherArray": { "type": "array", "items": { "type": "string", "title": "A string item" } },
+                    "objectWithArrayProp": {
+                        "type": "object",
+                        "title": "object with array",
+                        "properties": {
+                            "nestedArray": { "type": "array", "title": "A nested array", "items": { "type": "string", "title": "A nested string item" } }
+                        }
                     }
                 }
             },

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -162,7 +162,7 @@ export default class SchemaTable extends LitElement {
               : html`${this.generateTree(
                 data[key]['::type'] === 'array' ? data[key]['::props'] : data[key],
                 data[key]['::type'],
-                data[key]['::title'] && !Number.isNaN(key) ? '' : key,
+                subKey || key,
                 data[key]['::description'],
                 (level + 1),
               )}`

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -116,13 +116,13 @@ export default class SchemaTable extends LitElement {
       return html`<span class="td key object" style='padding-left:${leftPadding}px'>${key}</span>`;
     }
     let label = '';
-    let subLabel = '';
+    let optionNumber = '';
     if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF')) {
       label = key.replace('::', '').replace('~', ' ');
     } else if (key.startsWith('::OPTION')) {
       const parts = key.split('~');
-      label = parts[1];
-      subLabel = parts[2];
+      optionNumber = parts[1];
+      label = parts[2];
     } else {
       label = key;
     }
@@ -132,7 +132,7 @@ export default class SchemaTable extends LitElement {
           ? html`
             <div class='tr ${level < this.schemaExpandLevel ? 'expanded' : 'collapsed'} ${data['::type']}' data-obj='${label}'>
               <div class='td key' style='padding-left:${leftPadding}px'>
-                ${label
+                ${label || optionNumber
                   ? html`
                     <span 
                       class='obj-toggle ${level < this.schemaExpandLevel ? 'expanded' : 'collapsed'}'
@@ -144,7 +144,7 @@ export default class SchemaTable extends LitElement {
                   : ''
                 }
                 ${data['::type'] === 'xxx-of-option' || data['::type'] === 'xxx-of-array' || key.startsWith('::OPTION')
-                  ? html`<span class="xxx-of-key" style="margin-left:-6px">${label}</span><span class="xxx-of-descr">${subLabel}</span>`
+                  ? html`<span class="xxx-of-key" style="margin-left:-6px">${optionNumber}</span><span class="xxx-of-descr">${label}</span>`
                   : label.endsWith('*')
                     ? html`<span style="display:inline-block; margin-left:-6px;"> ${label.substring(0, label.length - 1)}</span><span style='color:var(--red);'>*</span>`
                     : html`<span style="display:inline-block; margin-left:-6px;">${label}</span>`
@@ -162,7 +162,7 @@ export default class SchemaTable extends LitElement {
               : html`${this.generateTree(
                 data[dataKey]['::type'] === 'array' ? data[dataKey]['::props'] : data[dataKey],
                 data[dataKey]['::type'],
-                subLabel || dataKey,
+                label || dataKey,
                 data[dataKey]['::description'],
                 (level + 1),
               )}`
@@ -178,10 +178,10 @@ export default class SchemaTable extends LitElement {
     return html`
       <div class = "tr primitive">
         <div class='td key' style='padding-left:${leftPadding}px' >
-          ${label.endsWith('*')
+          ${label?.endsWith('*')
             ? html`${label.substring(0, label.length - 1)}<span style='color:var(--red);'>*</span>`
             : key.startsWith('::OPTION')
-              ? html`<span class='xxx-of-key'>${label}</span><span class="xxx-of-descr">${itemParts[7]}</span>`
+              ? html`<span class='xxx-of-key'>${optionNumber}</span><span class="xxx-of-descr">${itemParts[7]}</span>`
               : html`${label || html`<span class="xxx-of-descr">${itemParts[7]}</span>`}`
           }
         </div>

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -162,7 +162,7 @@ export default class SchemaTable extends LitElement {
               : html`${this.generateTree(
                 data[dataKey]['::type'] === 'array' ? data[dataKey]['::props'] : data[dataKey],
                 data[dataKey]['::type'],
-                label || dataKey,
+                dataKey,
                 data[dataKey]['::description'],
                 (level + 1),
               )}`
@@ -186,7 +186,7 @@ export default class SchemaTable extends LitElement {
           }
         </div>
         <div class='td key-type ${dataTypeCss}'>
-          ${dataType === 'array' ? `[${itemParts[0]}]` : itemParts[0] } 
+          ${dataType === 'array' ? `[${itemParts[0]}]` : itemParts[0]} 
           <span style="font-family: var(--font-mono);">${itemParts[1]} </span> </div>
         <div class='td key-descr'>
           ${dataType === 'array' ? description : ''}

--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -107,63 +107,63 @@ export default class SchemaTable extends LitElement {
     `;
   }
 
-  generateTree(data, prevDataType = 'object', prevKey = '', prevDescr = '', level = 0) {
+  generateTree(data, dataType = 'object', key = '', description = '', level = 0) {
     const leftPadding = 16 * level; // 2 space indentation at each level
     if (!data) {
       return html`<div class="null" style="display:inline;">null</div>`;
     }
     if (Object.keys(data).length === 0) {
-      return html`<span class="td key object" style='padding-left:${leftPadding}px'>${prevKey}</span>`;
+      return html`<span class="td key object" style='padding-left:${leftPadding}px'>${key}</span>`;
     }
-    let newPrevKey = '';
-    let subKey = '';
-    if (prevKey.startsWith('::ONE~OF') || prevKey.startsWith('::ANY~OF')) {
-      newPrevKey = prevKey.replace('::', '').replace('~', ' ');
-    } else if (prevKey.startsWith('::OPTION')) {
-      const parts = prevKey.split('~');
-      newPrevKey = parts[1];
-      subKey = parts[2];
+    let label = '';
+    let subLabel = '';
+    if (key.startsWith('::ONE~OF') || key.startsWith('::ANY~OF')) {
+      label = key.replace('::', '').replace('~', ' ');
+    } else if (key.startsWith('::OPTION')) {
+      const parts = key.split('~');
+      label = parts[1];
+      subLabel = parts[2];
     } else {
-      newPrevKey = prevKey;
+      label = key;
     }
     if (typeof data === 'object') {
       return html`
         ${level > 0
           ? html`
-            <div class='tr ${level < this.schemaExpandLevel ? 'expanded' : 'collapsed'} ${data['::type']}' data-obj='${newPrevKey}'>
+            <div class='tr ${level < this.schemaExpandLevel ? 'expanded' : 'collapsed'} ${data['::type']}' data-obj='${label}'>
               <div class='td key' style='padding-left:${leftPadding}px'>
-                ${newPrevKey
+                ${label
                   ? html`
                     <span 
                       class='obj-toggle ${level < this.schemaExpandLevel ? 'expanded' : 'collapsed'}'
-                      data-obj='${newPrevKey}'
-                      @click= ${(e) => this.toggleObjectExpand(e, newPrevKey)} 
+                      data-obj='${label}'
+                      @click= ${(e) => this.toggleObjectExpand(e, label)} 
                     >
                       ${level < this.schemaExpandLevel ? '-' : '+'}
                     </span>`
                   : ''
                 }
-                ${data['::type'] === 'xxx-of-option' || data['::type'] === 'xxx-of-array' || prevKey.startsWith('::OPTION')
-                  ? html`<span class="xxx-of-key" style="margin-left:-6px">${newPrevKey}</span><span class="xxx-of-descr">${subKey}</span>`
-                  : newPrevKey.endsWith('*')
-                    ? html`<span style="display:inline-block; margin-left:-6px;"> ${newPrevKey.substring(0, newPrevKey.length - 1)}</span><span style='color:var(--red);'>*</span>`
-                    : html`<span style="display:inline-block; margin-left:-6px;">${newPrevKey}</span>`
+                ${data['::type'] === 'xxx-of-option' || data['::type'] === 'xxx-of-array' || key.startsWith('::OPTION')
+                  ? html`<span class="xxx-of-key" style="margin-left:-6px">${label}</span><span class="xxx-of-descr">${subLabel}</span>`
+                  : label.endsWith('*')
+                    ? html`<span style="display:inline-block; margin-left:-6px;"> ${label.substring(0, label.length - 1)}</span><span style='color:var(--red);'>*</span>`
+                    : html`<span style="display:inline-block; margin-left:-6px;">${label}</span>`
                 }
               </div>
               <div class='td key-type'>${(data['::type'] || '').includes('xxx-of') ? '' : data['::type']}</div>
-              <div class='td key-descr m-markdown-small' style='line-height:1.7'>${unsafeHTML(marked(prevDescr || ''))}</div>
+              <div class='td key-descr m-markdown-small' style='line-height:1.7'>${unsafeHTML(marked(description || ''))}</div>
             </div>`
           : ''
         }
         <div class='object-body'>
-          ${Object.keys(data).map((key) => html`
-            ${['::description', '::type', '::props'].includes(key)
+          ${Object.keys(data).map((dataKey) => html`
+            ${['::description', '::type', '::props'].includes(dataKey)
               ? ''
               : html`${this.generateTree(
-                data[key]['::type'] === 'array' ? data[key]['::props'] : data[key],
-                data[key]['::type'],
-                subKey || key,
-                data[key]['::description'],
+                data[dataKey]['::type'] === 'array' ? data[dataKey]['::props'] : data[dataKey],
+                data[dataKey]['::type'],
+                subLabel || dataKey,
+                data[dataKey]['::description'],
                 (level + 1),
               )}`
             }
@@ -178,41 +178,23 @@ export default class SchemaTable extends LitElement {
     return html`
       <div class = "tr primitive">
         <div class='td key' style='padding-left:${leftPadding}px' >
-          ${newPrevKey.endsWith('*')
-            ? html`${newPrevKey.substring(0, newPrevKey.length - 1)}<span style='color:var(--red);'>*</span>`
-            : prevKey.startsWith('::OPTION')
-              ? html`<span class='xxx-of-key'>${newPrevKey}</span><span class="xxx-of-descr">${itemParts[7]}</span>`
-              : html`${newPrevKey || html`<span class="xxx-of-descr">${itemParts[7]}</span>`}`
+          ${label.endsWith('*')
+            ? html`${label.substring(0, label.length - 1)}<span style='color:var(--red);'>*</span>`
+            : key.startsWith('::OPTION')
+              ? html`<span class='xxx-of-key'>${label}</span><span class="xxx-of-descr">${itemParts[7]}</span>`
+              : html`${label || html`<span class="xxx-of-descr">${itemParts[7]}</span>`}`
           }
         </div>
         <div class='td key-type ${dataTypeCss}'>
-          ${prevDataType === 'array'
-            ? `[${itemParts[0]}]`
-            : itemParts[0]
-          } 
+          ${dataType === 'array' ? `[${itemParts[0]}]` : itemParts[0] } 
           <span style="font-family: var(--font-mono);">${itemParts[1]} </span> </div>
         <div class='td key-descr'>
-          ${prevDataType === 'array' ? prevDescr : ''}
-          ${itemParts[2]
-            ? html`<div style='color: var(--fg2); padding-bottom:3px;'>${itemParts[4]}</div>`
-            : ''
-          }
-          ${itemParts[3]
-            ? html`<div style='color: var(--fg2); padding-bottom:3px;' ><span class='bold-text'>Default:</span> ${itemParts[3]}</div>`
-            : ''
-          }
-          ${itemParts[4]
-            ? html`<div style='color: var(--fg2); padding-bottom:3px;'><span class='bold-text'>Allowed: </span> &nbsp; ${itemParts[4]}</div>`
-            : ''
-          }
-          ${itemParts[5]
-            ? html`<div style='color: var(--fg2); padding-bottom:3px;'><span class='bold-text'>Pattern:</span>  &nbsp; ${itemParts[5]}</div>`
-            : ''
-          }
-          ${itemParts[6]
-            ? html`<span class="m-markdown-small">${unsafeHTML(marked(itemParts[6]))}</span>`
-            : ''
-          }
+          ${dataType === 'array' ? description : ''}
+          ${itemParts[2] ? html`<div style='color: var(--fg2); padding-bottom:3px;'>${itemParts[4]}</div>` : ''}
+          ${itemParts[3] ? html`<div style='color: var(--fg2); padding-bottom:3px;' ><span class='bold-text'>Default:</span> ${itemParts[3]}</div>` : ''}
+          ${itemParts[4] ? html`<div style='color: var(--fg2); padding-bottom:3px;'><span class='bold-text'>Allowed: </span> &nbsp; ${itemParts[4]}</div>` : ''}
+          ${itemParts[5] ? html`<div style='color: var(--fg2); padding-bottom:3px;'><span class='bold-text'>Pattern:</span>  &nbsp; ${itemParts[5]}</div>` : ''}
+          ${itemParts[6] ? html`<span class="m-markdown-small">${unsafeHTML(marked(itemParts[6]))}</span>` : ''}
         </div>
       </div>
     `;

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -107,7 +107,6 @@ export default class SchemaTree extends LitElement {
   }
 
   generateTree(data, prevDataType = 'object', prevKey = '', prevDescr = '', level = 0) {
-    delete data['::title'];
     if (!data) {
       return html`<div class="null" style="display:inline;">null</div>`;
     }

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -438,7 +438,7 @@ export function schemaInObjectNotation(schema, obj, level = 0, suffix = '') {
         objWithAnyOfProps['::type'] = 'xxx-of-option';
       } else if (v.type === 'array' || v.items) {
         // This else-if block never seems to get executed
-        const partialObj = [schemaInObjectNotation(v, {})];
+        const partialObj = schemaInObjectNotation(v, {});
         objWithAnyOfProps[`::OPTION~${index + 1}${v.title ? `~${v.title}` : ''}`] = partialObj;
         objWithAnyOfProps['::type'] = 'xxx-of-array';
       } else {
@@ -469,7 +469,6 @@ export function schemaInObjectNotation(schema, obj, level = 0, suffix = '') {
         : '');
     obj['::type'] = 'array';
     obj['::props'] = schemaInObjectNotation(schema.items, {}, (level + 1));
-    obj['::title'] = schema.items.title ? schema.items.title : '';
   } else {
     const typeObj = getTypeInfo(schema);
     if (typeObj.html) {


### PR DESCRIPTION
The labels for array items inside an `anyOf` or `oneOf`, for example with [this schema](https://sneakyvv.github.io/RapiDoc/specs/oneof-titles.json)

```
"employee": {
    "type": "object",
    [...]
    "properties": {
        [...]
        "employee": {
            "description": "Employee Details (Worker or Manager)",
            "oneOf": [
                [...]
                {
                    "type": "array",
                    "title": "An array title",
                    "description": "An array with a title",
                    "items": { "type": "string", "title": "an array item" }
                },
                {
                    "type": "array",
                    "description": "An array without a title",
                    "items": { "type": "string", "title": "an array item" }
                },
                { "type": "string", "description": "Primitive with a title", "title": "ID number" },
                { "type": "int", "description": "Primitive without a title" },
                { "type": "null", "description": "Null with a title", "title": "Null with a title" },
                { "type": "null", "description": "Null without a title" }
            ]
        },
        "anotherArray": { "type": "array", "items": { "type": "string", "title": "A string item" } },
        "objectWithArrayProp": {
            "type": "object",
            "title": "object with array",
            "properties": {
                "nestedArray": { "type": "array", "title": "A nested array", "items": { "type": "string", "title": "A nested string item" } }
            }
        }
    }
},
```

![initial](https://user-images.githubusercontent.com/1423157/100468953-b2270100-30d5-11eb-86ee-be788079b601.png)

was improved in #351 to **_(1)_**

![current](https://user-images.githubusercontent.com/1423157/100468969-b6ebb500-30d5-11eb-9655-aa7fe7503e03.png)

But it is now replacing the property titles for simple arrays too **_(2)_**, because the numeric condition in `schema-table.js` was not yet optimal.
Secondly, the arrays under a `anyOf`/`oneOf` were never correctly rendered either. They were nested too deep, and rendered as type `object` **_(3)_**

This PR fixes these issues so it becomes (see commit for details how)

![new](https://user-images.githubusercontent.com/1423157/100469017-cc60df00-30d5-11eb-98f1-7f2866323a3e.png)

See https://sneakyvv.github.io/RapiDoc/examples/oneof-titles.html#get-/one-of/employee
 