### PR TITLE
Use label from ::OPTION for anyOf/oneOf array

### DIFF
--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -183,7 +183,7 @@ export default class SchemaTable extends LitElement {
           ${label?.endsWith('*')
             ? html`${label.substring(0, label.length - 1)}<span style='color:var(--red);'>*</span>`
             : key.startsWith('::OPTION')
-              ? html`<span class='xxx-of-key'>${optionNumber}</span><span class="xxx-of-descr">${itemParts[7]}</span>`
+              ? html`<span class='xxx-of-key'>${optionNumber}</span><span class="xxx-of-descr">${label}</span>`
               : html`${label || html`<span class="xxx-of-descr">${itemParts[7]}</span>`}`
           }
         </div>


### PR DESCRIPTION
### Problem

See https://mrin9.github.io/RapiDoc/examples/oneof-titles.html

![image](https://user-images.githubusercontent.com/1423157/100551624-27373980-3282-11eb-8b66-13ef74eb60f9.png)

4 & 5 are always using the title from the `items`-schema. If there is no title, none will be shown, while it should be the title from that `array`-schema.

### Expected

See https://sneakyvv.github.io/RapiDoc/examples/oneof-titles.html

![image](https://user-images.githubusercontent.com/1423157/100551661-69607b00-3282-11eb-8c3c-50e3ac4bae9c.png)

PS: It could be the title of the `items`-schema for 5, but _if_ you would use that it's probably better if it were used in the type (so `[<items.title>]` instead of simply `[string]` for example. So the side effect is that 5 has no label anymore, but that's probably correct.

### Solution

262c84a added using `${itemsParts[7]}`. In my PR #367, I was already using `${label}` instead, but it conflicted with 262c84a, so I kept that version. 
I just noticed the problem with `items`-schemas now, and after a second review, it seems that `${label}` is actually correct since the title is always available as third part of `::OPTION`, but not always (or perhaps even never in the `::OPTION` case?) as `${itemsParts[7]}`.
So the solution: use `${label}` instead.
