### PR TITLE
Css selector for model type

### DIFF
--- a/src/components/schema-table.js
+++ b/src/components/schema-table.js
@@ -85,7 +85,7 @@ export default class SchemaTable extends LitElement {
           </div>
         </div>
           <div style='padding: 5px 0; color:var(--fg2)'> 
-            <span class='bold-text upper'> ${this.data ? this.data['::type'] : ''}</span> 
+            <span class="bold-text upper data-type" data-type="${this.data ? this.data['::type'] : ''}"> ${this.data ? this.data['::type'] : ''}</span> 
             <span class='m-markdown' >${this.data ? unsafeHTML(marked(this.data['::description'] || '')) : ''}</span>
           </div>
           <div style = "border:1px solid var(--light-border-color)">


### PR DESCRIPTION
### Problem
The XXX-OF at the top of a model table seems a bit odd.

![image](https://user-images.githubusercontent.com/1423157/100720489-5783f280-33be-11eb-9b47-c7d8b8c90ebe.png)

### Suggestion

Add CSS selector so you can choose to style it (hide it).