### PR TITLE
docs/examples: fix "add HTML" example

### DIFF
--- a/docs/examples.html
+++ b/docs/examples.html
@@ -183,14 +183,14 @@
 &lt;rapi-doc spec-url="https://petstore.swagger.io/v2/swagger.json"&gt;
 
   &lt;!-- content at the top --&gt;
-  &lt;p>This is an example to add external html content &lt;/li&gt;
-  &lt;p>Ypu may add &lt;/li&gt;
+  &lt;p&gt; This is an example of adding external HTML content. &lt;/li&gt;
+  &lt;p&gt; You may add: &lt;/li&gt;
   &lt;ul&gt;
-    &lt;li&gt; Table &lt;/li&gt;
+    &lt;li&gt; Tables &lt;/li&gt;
     &lt;li&gt; Text &lt;/li&gt;
     &lt;li&gt; Images &lt;/li&gt;
     &lt;li&gt; Links &lt;/li&gt;
-    &lt;li&gt; any HTML content &lt;/li&gt;
+    &lt;li&gt; Any HTML content &lt;/li&gt;
   &lt;/ul&gt;  
 
   &lt;!-- content at the bottom --&gt;


### PR DESCRIPTION
- Fix typo "ypu" --> "you"
- Fix "table" --> "tables" to match the other entries
- Various capitalization, spacing and punctuation tweaks
- Escape all angle brackets in code sample
- Tweak phrasing of first sentence, and tables