### PR TITLE
Replace unicode return-left with something more common

### DIFF
--- a/src/templates/header-template.js
+++ b/src/templates/header-template.js
@@ -25,7 +25,7 @@ export default function headerTemplate() {
             @change="${this.onSepcUrlChange}" 
             spellcheck="false" 
           >
-          <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x2b90;</div> 
+          <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x21a9;</div> 
         `
       } 
       ${(this.allowSpecFileLoad === 'false')
@@ -46,7 +46,7 @@ export default function headerTemplate() {
         ? ''
         : html`  
           <input id="search" class="header-input" type="text"  placeholder="Quick Search" @change="${this.onSearchChange}" style="max-width:130px;margin-left:10px;" spellcheck="false" >
-          <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x2b90;</div>
+          <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x21a9;</div>
         `
       }
       

--- a/src/templates/navbar-template.js
+++ b/src/templates/navbar-template.js
@@ -24,7 +24,7 @@ export default function navbarTemplate() {
                   @change = "${this.onSearchChange}"  
                   spellcheck = "false" 
                 >
-                <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x2b90;</div>
+                <div style="margin: 6px 5px 0 -24px; font-size:var(--title-font-size); cursor:pointer;">&#x21a9;</div>
               </div>  
               ${this.matchPaths
                 ? html`


### PR DESCRIPTION
## Problem

The unicode character at #X2B90 does not show up in many Linux fonts, and so renders in the UI as a white rectangle (Chome) or a rectangle with odd glyphs in it (Firefox).

## Proposed Solution

This replaces the use of those codes with the similar, but far more common, #21A9.

If your browser can render them, it replaces RETURN LEFT' (U+2B90) ⮐ with LEFTWARDS ARROW WITH HOOK (U+21A9), ↩   (which Github unhelpfully converts to the emoji version, but isn't actually what you'd see in the final build)

### References

Courtesy of FileFormat.info:

* Browser [test page](https://www.fileformat.info/info/unicode/char/2b90/browsertest.htm) for 2B90
  * list of [supported fonts](https://www.fileformat.info/info/unicode/char/2b90/fontsupport.htm) (6)
* Unicode [info on 21A9](https://www.fileformat.info/info/unicode/char/21a9/index.htm)
  * list of [supported fonts](https://www.fileformat.info/info/unicode/char/21a9/fontsupport.htm) (way more than 6)
