### PR TITLE
Fix parsing empty responses

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1222,7 +1222,10 @@ export default class ApiRequest extends LitElement {
         me.responseHeaders = `${me.responseHeaders}${hdr.trim()}: ${hdrVal}\n`;
       });
       const contentType = tryResp.headers.get('content-type');
-      if (contentType) {
+      const respEmpty = (await tryResp.clone().text()).length === 0;
+      if (respEmpty) {
+        respText = '';
+      } else if (contentType) {
         if (contentType.includes('json')) {
           if ((/charset=[^"']+/).test(contentType)) {
             const encoding = contentType.split('charset=')[1];


### PR DESCRIPTION
When a `Content-Type` header (e.g. `application/json`) is given when there is actually no content (e.g. in a `204` response), you currently get this
![image](https://user-images.githubusercontent.com/1423157/110754896-9ab8f180-8248-11eb-8d12-05aadfffebec.png)
This is because it's trying to parse "nothing" as JSON, which fails. A side effect is that the response box is not updated, and still contains the response from a potential previous request.

This is fixed by checking if the response is empty before attempting (any sort of) parsing.