### PR TITLE
Follow-up: Fix parsing empty responses

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1219,7 +1219,7 @@ export default class ApiRequest extends LitElement {
       const tryResp = await fetch(fetchUrl, fetchOptions);
       tryBtnEl.disabled = false;
       me.responseStatus = tryResp.ok ? 'success' : 'error';
-      me.responseMessage = `${tryResp.statusText}:${tryResp.status}`;
+      me.responseMessage = tryResp.statusText ? `${tryResp.statusText}:${tryResp.status}` : tryResp.status;
       me.responseUrl = tryResp.url;
       tryResp.headers.forEach((hdrVal, hdr) => {
         me.responseHeaders = `${me.responseHeaders}${hdr.trim()}: ${hdrVal}\n`;

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1227,7 +1227,7 @@ export default class ApiRequest extends LitElement {
       const contentType = tryResp.headers.get('content-type');
       const respEmpty = (await tryResp.clone().text()).length === 0;
       if (respEmpty) {
-        respText = '';
+        me.responseText = '';
       } else if (contentType) {
         if (contentType.includes('json')) {
           if ((/charset=[^"']+/).test(contentType)) {


### PR DESCRIPTION
I noticed the fix in PR #434 wasn't correct (the wrong variable was set to empty, so the response box wasn't getting cleared, in case you already had a response from a previous request), and I already pushed extra commits to my branch, but didn't notice you already merged the other PR.

So this is a rebase of my branch.