### PR TITLE
Make sub titles consistent

### DIFF
--- a/src/templates/server-template.js
+++ b/src/templates/server-template.js
@@ -74,7 +74,7 @@ function serverVarsTemplate() {
 export default function serverTemplate() {
   return html`
   <section id = 'servers' style="margin-top:24px; margin-bottom:24px;" class='regular-font observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap'}'>
-    <div class = 'sub-title'> API SERVER: </div>
+    <div class = 'sub-title'> API SERVER </div>
     <div class = 'mono-font' style='margin: 12px 0; font-size:calc(var(--font-size-small) + 1px);'>
       ${this.resolvedSpec.servers?.length === 0
         ? ''


### PR DESCRIPTION
There was only one (sub)title with a colon after it. Can we make this consistent by removing this one colon?