### PR TITLE
Fix allowed values splitting to use ┃

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -331,7 +331,7 @@ export default class ApiRequest extends LitElement {
                 ${paramSchema.default ? html`<span style="font-weight:bold">Default: </span>${paramSchema.default}<br/>` : ''}
                 ${paramSchema.pattern ? html`<span style="font-weight:bold">Pattern: </span>${paramSchema.pattern}<br/>` : ''}
                 ${paramSchema.constrain ? html`${paramSchema.constrain}<br/>` : ''}
-                ${paramSchema.allowedValues && paramSchema.allowedValues.split(',').map((v, i) => html`
+                ${paramSchema.allowedValues && paramSchema.allowedValues.split('┃').map((v, i) => html`
                   ${i > 0 ? ' | ' : html`<span style="font-weight:bold"> Allowed: </span>`}
                   ${html`
                     <a part="anchor anchor-param-constraint" class = "${this.allowTry === 'true' ? '' : 'inactive-link'}"
@@ -771,7 +771,7 @@ export default class ApiRequest extends LitElement {
                       ${paramSchema.default ? html`<span style="font-weight:bold">Default: </span>${paramSchema.default}<br/>` : ''}
                       ${paramSchema.pattern ? html`<span style="font-weight:bold">Pattern: </span>${paramSchema.pattern}<br/>` : ''}
                       ${paramSchema.constrain ? html`${paramSchema.constrain}<br/>` : ''}
-                      ${paramSchema.allowedValues && paramSchema.allowedValues.split(',').map((v, i) => html`
+                      ${paramSchema.allowedValues && paramSchema.allowedValues.split('┃').map((v, i) => html`
                         ${i > 0 ? ' | ' : html`<span style="font-weight:bold"> Allowed: </span>`}
                         ${html`
                           <a part="anchor anchor-param-constraint" class = "${this.allowTry === 'true' ? '' : 'inactive-link'}"


### PR DESCRIPTION
AllowedValues are separated with a `┃` not a `,`.

![image](https://user-images.githubusercontent.com/5056218/112651635-e379c880-8e4c-11eb-9814-66151a6692cd.png)
