### PR TITLE
Do not show read only properties in request body forms

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -687,6 +687,9 @@ export default class ApiRequest extends LitElement {
     if (schema.properties) {
       for (const fieldName in schema.properties) {
         const fieldSchema = schema.properties[fieldName];
+        if (fieldSchema.readOnly) {
+          continue;
+        }
         const fieldExamples = fieldSchema.examples || fieldSchema.example || '';
         const fieldType = fieldSchema.type;
         const paramSchema = getTypeInfo(fieldSchema);


### PR DESCRIPTION
Read only properties are already properly omitted in application/json view but not in application/x-www-form-urlencoded and multipart/form-data views. This branch excludes them from the generated form