### PR TITLE
Add page-direction attribute to rapi-doc html tag

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -108,6 +108,7 @@ export default class ApiRequest extends LitElement {
           min-height:220px; 
           padding:5px;
           resize:vertical;
+          direction: ltr;
         }
         .example:first-child {
           margin-top: -9px;

--- a/src/components/api-response.js
+++ b/src/components/api-response.js
@@ -62,6 +62,7 @@ export default class ApiResponse extends LitElement {
       .resp-descr{
         font-size:calc(var(--font-size-small) + 1px);
         color:var(--light-fg);
+        text-align:left;
       }
       .top-gap{margin-top:16px;}
       .example-panel{

--- a/src/components/json-tree.js
+++ b/src/components/json-tree.js
@@ -30,6 +30,8 @@ export default class JsonTree extends LitElement {
         word-break: break-all;
         flex:1;
         line-height: calc(var(--font-size-small) + 6px);
+        direction: ltr; 
+        text-align: left;
       }
 
       .open-bracket{

--- a/src/components/schema-tree.js
+++ b/src/components/schema-tree.js
@@ -35,6 +35,7 @@ export default class SchemaTree extends LitElement {
       .tree {
         font-size:var(--font-size-small);
         text-align: left;
+        direction: ltr;
         line-height:calc(var(--font-size-small) + 6px);
       }
       .tree .tr:hover{

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -90,6 +90,7 @@ export default class RapiDoc extends LitElement {
       allowServerSelection: { type: String, attribute: 'allow-server-selection' },
       allowSchemaDescriptionExpandToggle: { type: String, attribute: 'allow-schema-description-expand-toggle' },
       showComponents: { type: String, attribute: 'show-components' },
+      pageDirection: { type: String, attribute: 'page-direction' },
 
       // Main Colors and Font
       theme: { type: String },

--- a/src/styles/font-styles.js
+++ b/src/styles/font-styles.js
@@ -24,6 +24,7 @@ export default css`
     font-size: calc(var(--font-size-small) + 4px);
     font-weight:bold;
     margin-bottom:8px;
+    text-align:left;
   }
   .tiny-title { 
     font-size:calc(var(--font-size-small) + 1px); 

--- a/src/styles/table-styles.js
+++ b/src/styles/table-styles.js
@@ -8,6 +8,7 @@ export default css`
   border-radius: var(--border-radius);
   margin: 0;
   max-width: 100%;
+  direction: ltr;
 }
 .m-table tr:first-child td,
 .m-table tr:first-child th {

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -55,7 +55,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
       ${path.isWebhook
         ? html`<span style="color:var(--primary-color); font-weight:bold; font-size: var(--font-size-regular);"> WEBHOOK </span>`
         : html`
-          <div class='mono-font part="section-operation-url" regular-font-size' style='padding: 8px 0; color:var(--fg3)'> 
+          <div class='mono-font part="section-operation-url" regular-font-size' style='text-align:left; direction:ltr; padding: 8px 0; color:var(--fg3)'> 
             <span part="label-operation-method" class='regular-font upper method-fg bold-text ${path.method}'>${path.method}</span> 
             <span part="label-operation-path">${path.path}</span>
           </div>

--- a/src/templates/main-body-template.js
+++ b/src/templates/main-body-template.js
@@ -70,7 +70,7 @@ export default function mainBodyTemplate(isMini = false, showExpandCollapse = tr
     <!-- Advanced Search -->
     ${this.allowAdvancedSearch === 'false' ? '' : advancedSearchTemplate.call(this)}
 
-    <div id='the-main-body' class="body">
+    <div id='the-main-body' class="body" dir= ${this.pageDirection}>
       <!-- Side Nav -->
       ${((this.renderStyle === 'read' || this.renderStyle === 'focused')
           && this.showSideNav === 'true'

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -329,7 +329,7 @@ export default function securitySchemeTemplate() {
     return;
   }
   return html`
-  <section id='auth' part="section-auth" style="margin-top:24px; margin-bottom:24px;" class = 'observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap '}'>
+  <section id='auth' part="section-auth" style="text-align:left; direction:ltr; margin-top:24px; margin-bottom:24px;" class = 'observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap '}'>
     <div class='sub-title regular-font'> AUTHENTICATION </div>
 
     <div class="small-font-size" style="display:flex; align-items: center; min-height:30px">

--- a/src/templates/server-template.js
+++ b/src/templates/server-template.js
@@ -75,7 +75,7 @@ function serverVarsTemplate() {
 export default function serverTemplate() {
   if (!this.resolvedSpec || this.resolvedSpec.specLoadError) { return ''; }
   return html`
-  <section id = 'servers' part="section-servers" style="margin-top:24px; margin-bottom:24px;" class='regular-font observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap'}'>
+  <section id = 'servers' part="section-servers" style="text-align:left; direction:ltr; margin-top:24px; margin-bottom:24px;" class='regular-font observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap'}'>
     <div class = 'sub-title'>API SERVER</div>
     <div class = 'mono-font' style='margin: 12px 0; font-size:calc(var(--font-size-small) + 1px);'>
       ${!this.resolvedSpec.servers || this.resolvedSpec.servers?.length === 0


### PR DESCRIPTION
I added an attribute called "page-direction" to rapi-doc tag, to be able to use both rtl and ltr directions.
Other added styles are just for preventing English texts from going right, while using rtl.