### PR TITLE
Avoid modifying curl post body

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1257,11 +1257,15 @@ export default class ApiRequest extends LitElement {
         const exampleTextAreaEl = requestPanelEl.querySelector('.request-body-param-user-input');
         if (exampleTextAreaEl?.value) {
           fetchOptions.body = exampleTextAreaEl.value;
-          // curlData = ` -d ${JSON.stringify(exampleTextAreaEl.value.replace(/(\r\n|\n|\r)/gm, '')).replace(/\\"/g, "'")} \\ \n`;
-          try {
-            curlData = ` -d '${JSON.stringify(JSON.parse(exampleTextAreaEl.value))}' \\\n`;
-          } catch (err) {
-            curlData = ` -d '${exampleTextAreaEl.value.replace(/(\r\n|\n|\r)/gm, '')}' \\\n`;
+          if (requestBodyType.includes('json')) {
+            try {
+              curlData = ` -d '${JSON.stringify(JSON.parse(exampleTextAreaEl.value))}' \\\n`;
+            } catch (err) {
+              // Ignore.
+            }
+          }
+          if (!curlData) {
+            curlData = ` -d '${exampleTextAreaEl.value.replace(/'/g, '\'"\'"\'')}' \\\n`;
           }
         }
       }


### PR DESCRIPTION
Only try `JSON.stringify(JSON.parse())` round-trip if body type is json, and otherwise do not strip newlines as those may mean something to the recipient server (so the given example shouldn't be modified).

See https://aoc.fornwall.net/api/ for an example where the curl command alters the post body in a bad way. There the `text/plain` body example of:

```text
1721
979
366
299
675
1456
```

currently generates the curl command:

```sh
curl -X POST "https://advent.fly.dev/solve/2020/1/1" \
 -H "Accept: text/plain" \
 -H "Content-Type: text/plain" \
 -d '17219793662996751456' 
```

while after this change the curl command is the expected:

```sh
curl -X POST "https://advent.fly.dev/solve/2020/1/1" \
 -H "Accept: text/plain" \
 -H "Content-Type: text/plain" \
 -d '1721
979
366
299
675
1456' 
```