### PR TITLE
Fix example generation for request objects without examples and mimeType

### DIFF
--- a/docs/specs/dynamic-query-params.yaml
+++ b/docs/specs/dynamic-query-params.yaml
@@ -75,6 +75,25 @@ paths:
                               type: string
                           additionalProperties:
                           type: string
+                  - in: query
+                    name: dynamic-query-params5
+                    explode: false
+                    required: false
+                    schema:
+                      type: object
+                      properties:
+                        propertyOne:
+                          type: string
+                          enum:
+                            - VALUE-1
+                            - VALUE-2
+                          default: VALUE-2
+                        propertyTwo:
+                          type: string
+                          enum:
+                            - FLAG-1
+                            - FLAG-2
+                          default: FLAG-1
                 responses:
                   '200':
                     description: successful operation
@@ -187,6 +206,28 @@ paths:
                     type: string
                 additionalProperties:
                   type: string
+        - in: query
+          name: dynamic-query-params5
+          description: >
+            Example generation works for non-exloded objects:<br />
+            `propertyOne=VALUE-1&property2=FLAG-1`
+          explode: false
+          required: false
+          schema:
+            type: object
+            properties:
+              propertyOne:
+                type: string
+                enum:
+                  - VALUE-1
+                  - VALUE-2
+                default: VALUE-2
+              propertyTwo:
+                type: string
+                enum:
+                  - FLAG-1
+                  - FLAG-2
+                default: FLAG-1
       responses:
         '200':
           description: successful operation

--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -311,7 +311,7 @@ export default class ApiRequest extends LitElement {
           '',
           '',
           declaredParamSchema,
-          serializeStyle,
+          serializeStyle || 'json',
           true,
           true,
           'text',

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -661,7 +661,7 @@ export function generateExample(examples = '', example = '', schema, mimeType, i
     for (const eg in examples) {
       let egContent = '';
       let egFormat = 'json';
-      if (mimeType.toLowerCase().includes('json')) {
+      if (mimeType?.toLowerCase().includes('json')) {
         if (outputType === 'text') {
           egContent = typeof examples[eg].value === 'string' ? examples[eg].value : JSON.stringify(examples[eg].value, undefined, 2);
           egFormat = 'text';
@@ -695,7 +695,7 @@ export function generateExample(examples = '', example = '', schema, mimeType, i
   } else if (example) {
     let egContent = '';
     let egFormat = 'json';
-    if (mimeType.toLowerCase().includes('json')) {
+    if (mimeType?.toLowerCase().includes('json')) {
       if (outputType === 'text') {
         egContent = typeof example === 'string' ? example : JSON.stringify(example, undefined, 2);
         egFormat = 'text';
@@ -734,14 +734,14 @@ export function generateExample(examples = '', example = '', schema, mimeType, i
           exampleDescription: '',
           exampleType: mimeType,
           exampleValue: schema.example,
-          exampleFormat: ((mimeType.toLowerCase().includes('json') && typeof schema.example === 'object') ? 'json' : 'text'),
+          exampleFormat: ((mimeType?.toLowerCase().includes('json') && typeof schema.example === 'object') ? 'json' : 'text'),
         });
-      } else if (mimeType.toLowerCase().includes('json') || mimeType.toLowerCase().includes('text') || mimeType.toLowerCase().includes('*/*') || mimeType.toLowerCase().includes('xml')) {
+      } else if (mimeType?.toLowerCase().includes('json') || mimeType?.toLowerCase().includes('text') || mimeType?.toLowerCase().includes('*/*') || mimeType?.toLowerCase().includes('xml')) {
         let xmlRootStart = '';
         let xmlRootEnd = '';
         let exampleFormat = '';
         let exampleValue = '';
-        if (mimeType.toLowerCase().includes('xml')) {
+        if (mimeType?.toLowerCase().includes('xml')) {
           xmlRootStart = (schema.xml && schema.xml.name) ? `<${schema.xml.name}>` : '<root>';
           xmlRootEnd = (schema.xml && schema.xml.name) ? `</${schema.xml.name}>` : '</root>';
           exampleFormat = 'text';
@@ -767,7 +767,7 @@ export function generateExample(examples = '', example = '', schema, mimeType, i
           const description = samples[samplesKey]['::DESCRIPTION'] || '';
           removeTitlesAndDescriptions(samples[samplesKey]);
 
-          if (mimeType.toLowerCase().includes('xml')) {
+          if (mimeType?.toLowerCase().includes('xml')) {
             exampleValue = `${xmlRootStart}${json2xml(samples[samplesKey])}\n${xmlRootEnd}`;
           } else {
             exampleValue = outputType === 'text' ? JSON.stringify(samples[samplesKey], null, 2) : samples[samplesKey];
@@ -819,7 +819,7 @@ function getSerializeStyleForContentType(contentType) {
 
 export function getSchemaFromParam(param) {
   if (param.schema) {
-    return [param.schema, null];
+    return [param.schema, null, null];
   }
   if (param.content) {
     // we gonna use the first content-encoding
@@ -829,5 +829,5 @@ export function getSchemaFromParam(param) {
       }
     }
   }
-  return [null, null];
+  return [null, null, null];
 }


### PR DESCRIPTION
Example generation dereferences `mimeType` which isn't always available for request objects. Request objects now default to JSON generation since this is what the user is expected to enter anyway. Also added optional chaining operator to be safe for the future.