### PR TITLE
enh: autofill form inputs without reusing previously filled values

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -3,7 +3,8 @@ import marked from 'marked';
 import Prism from 'prismjs';
 
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-// import { live } from 'lit-html/directives/live';
+import { guard } from 'lit-html/directives/guard';
+import { live } from 'lit-html/directives/live';
 import TableStyles from '~/styles/table-styles';
 import FlexStyles from '~/styles/flex-styles';
 import InputStyles from '~/styles/input-styles';
@@ -192,11 +193,11 @@ export default class ApiRequest extends LitElement {
         ${this.callback === 'true' ? 'CALLBACK REQUEST' : 'REQUEST'}
       </div>
       <div>
-        ${this.inputParametersTemplate('path')}
-        ${this.inputParametersTemplate('query')}
+        ${guard([this.parameters], () => this.inputParametersTemplate('path'))}
+        ${guard([this.parameters], () => this.inputParametersTemplate('query'))}
         ${this.requestBodyTemplate()}
-        ${this.inputParametersTemplate('header')}
-        ${this.inputParametersTemplate('cookie')}
+        ${guard([this.parameters], () => this.inputParametersTemplate('header'))}
+        ${guard([this.parameters], () => this.inputParametersTemplate('cookie'))}
         ${this.allowTry === 'false' ? '' : html`${this.apiCallTemplate()}`}
       </div>  
     </div>
@@ -400,7 +401,7 @@ export default class ApiRequest extends LitElement {
                       data-pname="${param.name}" 
                       data-example="${Array.isArray(example.exampleVal) ? example.exampleVal.join('~|~') : example.exampleVal}"
                       data-array="false"
-                      .value="${this.fillRequestFieldsWithExample === 'true' ? example.exampleVal : ''}"
+                      .value="${live(this.fillRequestFieldsWithExample === 'true' ? example.exampleVal : '')}"
                     />`
                 }
             </td>`


### PR DESCRIPTION
I'm trying to implement rapidoc on mi website, but i'm having some issues with `fill-request-fields-with-example` option on `focused` mode. Here are the steps to reproduce the problem:
1. Press `Fill example` button on one of the views
2. Navigate to other view

You'll see that input values filled on first view will be reused on the second one.

In my case if I navigate to `GET /v1/contents/assets` and press the `Fill example` button I get `Power generation,Meteologica` as value of the input:
![image](https://user-images.githubusercontent.com/92851105/139103513-dd7e69cf-e673-4b0a-9da1-1f2fd6dffe65.png)

If after that I navigate to `GET /v1/assets` the first input is autofilled with the same value (`Power generation,Meteologica`):
![image](https://user-images.githubusercontent.com/92851105/139103575-0a6b7c90-e1e3-496c-aa83-b809391e56e5.png)

I've been inspecting the DOM tree and the problem is that **new view's DOM reuses the DOM of the previous one: it creates DOM elements that does not exist previously and it only updates the attributes that have changed on the elements that are being reused**. That's fine, it's the expected behaviour, but when a native input is being reused the value is not updated properly. lit-html provides **`live` directive** to solve this kind of issues with native inputs. It **updates the value of the property/attribute if the value differs from the value rendered** in the "live element" of the DOM.

With that said, if I use `live` directive to set the value of native inputs all works fine. Now I can fill examples in one view and get clear inputs on the next ones. But this leads me to other problem: on every re-render the filled value gets dropped because of the live directive, e.g. when I make a login request using the `Try` button the view is being re-rendered and the value filled on the form is being dropped. I think that **re-renders on the form are unnecesary** on that cases, because the form's inputs depends on `parameters` property, and `parameters` is not being changed at all. To solve that I prupose to use `guard` directive, which purpose is to prevent renders unless one dependency has changed.