### PR TITLE
Wait update before sending spec-loaded

### DIFF
--- a/src/rapidoc-mini.js
+++ b/src/rapidoc-mini.js
@@ -318,6 +318,8 @@ export default class RapiDocMini extends LitElement {
       }
     }
     this.requestUpdate();
+    // eslint-disable-next-line no-await-in-loop
+    while (!await this.updateComplete);
     const specLoadedEvent = new CustomEvent('spec-loaded', { detail: spec });
     this.dispatchEvent(specLoadedEvent);
   }

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -709,6 +709,8 @@ export default class RapiDoc extends LitElement {
       }
     }
     this.requestUpdate();
+    // eslint-disable-next-line no-await-in-loop
+    while (!await this.updateComplete);
     const specLoadedEvent = new CustomEvent('spec-loaded', { detail: spec });
     this.dispatchEvent(specLoadedEvent);
 


### PR DESCRIPTION
The documentation says that spec-loaded is sent after the rendering is complete, but the current implementation only requests an update, then fires the event without waiting its completion.

With this change, all the needed updates are waited until the event is dispatched.

Thank you @bhdurak for discovering the bug and helping me test the code!