### PR TITLE
fixed Query parameters default value is not rendered if the value is 0 or false

### DIFF
--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -32,7 +32,7 @@ export function getTypeInfo(schema) {
     readOrWriteOnly: (schema.readOnly ? '🆁' : schema.writeOnly ? '🆆' : ''),
     deprecated: schema.deprecated ? '❌' : '',
     examples: schema.examples || schema.example,
-    default: schema.default || '',
+    default: schema.default != null ? `${schema.default}` : '',
     description: schema.description || '',
     constrain: '',
     allowedValues: '',


### PR DESCRIPTION
Hi,
I've noticed that falsy default values (0, false) are not rendered both in query parameters section and in schema section

#591

