### PR TITLE
Add lit-element dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "rapidoc",
-  "version": "9.1.8",
+  "version": "9.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rapidoc",
-      "version": "9.1.8",
+      "version": "9.2.0",
       "license": "MIT",
       "dependencies": {
         "@apitools/openapi-parser": "^0.0.24",
         "base64-arraybuffer": "^1.0.2",
         "buffer": "^6.0.3",
         "lit": "^2.2.0",
+        "lit-element": "^3.2.0",
         "marked": "^4.0.12",
         "prismjs": "^1.26.0"
       },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "base64-arraybuffer": "^1.0.2",
     "buffer": "^6.0.3",
     "lit": "^2.2.0",
+    "lit-element": "^3.2.0",
     "marked": "^4.0.12",
     "prismjs": "^1.26.0"
   },


### PR DESCRIPTION
When running `npm run build` with a custom css file, this error is shown, because of the lit-element import:

```
1:1  error  'lit-element' should be listed in the project's dependencies. Run 'npm i -S lit-element' to add it  import/no-extraneous-dependencies
```

This dependency needs to be declared, and that's what this PR does.
