### PR TITLE
Match documentation with example file of custom-styles.js

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -871,7 +871,7 @@
                   <code class="language-js">
                     // src/styles/custom-styles.js
 
-                    import { css } from 'lit-element';
+                    import { css } from 'lit';
                     export default css`
                       .tag.title {
                         text-transform: capitalize;


### PR DESCRIPTION
The documentation is saying you should import `lit-element`, which leads to build errors (as mentioned in https://github.com/mrin9/RapiDoc/pull/688).

The [example file](https://github.com/mrin9/RapiDoc/blob/master/src/styles/custom-styles.js#L1) however is importing `lit`. With this import there are no dependency errors when building.

So, the documentation needs to be updated.