### PR TITLE
New attributes for UI control

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -130,6 +130,13 @@ export default class RapiDoc extends LitElement {
       focusedElementId: { type: String }, // updating the focusedElementId will automatically render appropriate section in focused mode
       showAdvancedSearchDialog: { type: Boolean },
       advancedSearchMatches: { type: Object },
+
+      //section collapse action
+      expandCollapseSectionAction :  { type: Boolean, attribute: 'show-section-collapse' },
+      //main body class for custom css
+      mainBodyCssClass: { type: String, attribute: 'main-css-class' },
+      //add custom css file
+      customCssFile: { type: String, attribute: 'custom-css-file' },
     };
   }
 
@@ -472,6 +479,9 @@ export default class RapiDoc extends LitElement {
 
     if (!this.showAdvancedSearchDialog) { this.showAdvancedSearchDialog = false; }
 
+    if (!this.expandCollapseSectionAction) { this.expandCollapseSectionAction = false; }
+    if (!this.mainBodyCssClass) { this.mainBodyCssClass = ""; }
+    if (!this.customCssFile) { this.customCssFile = null; }
     marked.setOptions({
       highlight: (code, lang) => {
         if (Prism.languages[lang]) {
@@ -504,6 +514,11 @@ export default class RapiDoc extends LitElement {
 
   render() {
     // return render(mainBodyTemplate(this), this.shadowRoot, { eventContext: this });
+    const rapipdfCustomCSS = document.querySelector(`link[href*="${this.customCssFile}"]`);
+     // adding custom style for RapiDoc
+     if (rapipdfCustomCSS) {
+      this.shadowRoot.appendChild(rapipdfCustomCSS.cloneNode());
+    }
     return mainBodyTemplate.call(this);
   }
 
@@ -709,7 +724,7 @@ export default class RapiDoc extends LitElement {
     }
     if (!this.selectedServer) {
       if (this.resolvedSpec.servers) {
-        this.selectedServer = this.resolvedSpec.servers[0]; // eslint-disable-line prefer-destructuring
+        this.selectedServer = this.resolvedSpec.servers[0];
       }
     }
     this.requestUpdate();

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -167,7 +167,7 @@ function endpointBodyTemplate(path) {
 export default function endpointTemplate(showExpandCollapse = true, showTags = true, pathsExpanded = false) {
   if (!this.resolvedSpec) { return ''; }
   return html`
-    ${showExpandCollapse
+    ${showExpandCollapse && this.expandCollapseSectionAction 
       ? html`
         <div style="display:flex; justify-content:flex-end;"> 
           <span @click="${(e) => onExpandCollapseAll(e, 'expand-all')}" style="color:var(--primary-color); cursor:pointer;">

--- a/src/templates/main-body-template.js
+++ b/src/templates/main-body-template.js
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html } from 'lit-element';
 
 // Templates
 import expandedEndpointTemplate from '~/templates/expanded-endpoint-template';
@@ -73,7 +73,7 @@ export default function mainBodyTemplate(isMini = false, showExpandCollapse = tr
     <!-- Advanced Search -->
     ${this.allowAdvancedSearch === 'false' ? '' : advancedSearchTemplate.call(this)}
 
-    <div id='the-main-body' class="body" dir= ${this.pageDirection}>
+    <div id='the-main-body' class="body ${this.mainBodyCssClass}" dir= ${this.pageDirection}>
       <!-- Side Nav -->
       ${((this.renderStyle === 'read' || this.renderStyle === 'focused')
           && this.showSideNav === 'true'


### PR DESCRIPTION
Remove expand/collapse via a property setting
To add attribute called “show-section-collapse“,  default value for this attribute is false
To show expand/collapse section control has to set the value true like below.
`<rapi-doc id="thedoc" 
                  ................
                  show-section-collapse ="true" > </rapi-doc>`
 -------------------------------------------------------------------------------------------------------------------------------
 To add custom style with CSS file and a custom class on the main body
 To add custom class in the main body added attribute called "main-css-class" use it like below 
 `<rapi-doc id="thedoc" 
                  ................
                  main-css-class="custom-css-class-name" > </rapi-doc>`
                  
   --------------------------------------------------------------------------------------------------------------------------------
   To add ref of style sheet add attribute called "custom-css-file" use it like below 
    `<rapi-doc id="thedoc" 
                  ................
                  custom-css-file="custom-css-file-name" > </rapi-doc>`
 
 