### PR TITLE
Fix "oneOf" example generation

### DIFF
--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -389,12 +389,10 @@ export function schemaToSampleObj(schema, config = { }) {
         const oneOfSamples = schemaToSampleObj(schema.oneOf[key], config);
         for (const sampleKey in oneOfSamples) {
           // 2. In the final example include a one-of item along with properties
-          if (oneOfSamples[sampleKey] === null) {
-            const finalExample = Object.assign(oneOfSamples[sampleKey], objWithSchemaProps);
-            obj[`example-${i}`] = finalExample;
-            addSchemaInfoToExample(schema.oneOf[key], obj[`example-${i}`]);
-            i++;
-          }
+          const finalExample = Object.assign(oneOfSamples[sampleKey] || {}, objWithSchemaProps);
+          obj[`example-${i}`] = finalExample;
+          addSchemaInfoToExample(schema.oneOf[key], obj[`example-${i}`]);
+          i++;
         }
       }
     }


### PR DESCRIPTION
The "oneOf" example generation is broken in RapiDoc 9.2.0. E.g. if looking at the "oneof.yaml" schema:

![thtpryg1Ft](https://user-images.githubusercontent.com/82883363/160153836-cdceff04-7f54-4636-bf30-cf8a742043d4.png)

