### PR TITLE
enh: allow to define request body render style

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -66,6 +66,7 @@ export default class RapiDoc extends LitElement {
       useSummaryToListExamples: { type: String, attribute: 'use-summary-to-list-example' },
       persistAuth: { type: String, attribute: 'persist-auth' },
       onNavTagClick: { type: String, attribute: 'on-nav-tag-click' },
+      requestBodyRenderStyle: { type: String, attribute: 'request-body-render-style' }, // 'splitted' | 'default'
 
       // Schema Styles
       schemaStyle: { type: String, attribute: 'schema-style' },

--- a/src/templates/callback-template.js
+++ b/src/templates/callback-template.js
@@ -33,6 +33,7 @@ export default function callbackTemplate(callbacks) {
                       allow-try = "false"
                       render-style="${this.renderStyle}" 
                       schema-style = "${this.schemaStyle}"
+                      request-body-render-style="${this.requestBodyRenderStyle}"
                       active-schema-tab = "${this.defaultSchemaTab}"
                       schema-expand-level = "${this.schemaExpandLevel}"
                       schema-description-expanded = "${this.schemaDescriptionExpanded}"

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -133,6 +133,7 @@ function endpointBodyTemplate(path) {
           accept = "${accept}"
           render-style="${this.renderStyle}" 
           schema-style = "${this.schemaStyle}" 
+          request-body-render-style="${this.requestBodyRenderStyle}"
           schema-expand-level = "${this.schemaExpandLevel}"
           schema-description-expanded = "${this.schemaDescriptionExpanded}"
           allow-schema-description-expand-toggle = "${this.allowSchemaDescriptionExpandToggle}"

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -84,6 +84,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
         accept = "${accept}"
         render-style="${this.renderStyle}" 
         schema-style = "${this.schemaStyle}"
+        request-body-render-style="${this.requestBodyRenderStyle}"
         active-schema-tab = "${this.defaultSchemaTab}"
         schema-expand-level = "${this.schemaExpandLevel}"
         schema-description-expanded = "${this.schemaDescriptionExpanded}"


### PR DESCRIPTION
This PR adds a new property `requestBodyRenderStyle` in order to allow customizations on the request body section.
My proposal is to have two modes:
1. `splitted` mode, which renders two panes, one for the expected schema and other for the body input
2. `default` mode, which renders the request section on tabs

The following picture shows the `splitted` mode render:

![image](https://user-images.githubusercontent.com/92851105/162410172-d4e68e57-59d4-4a27-ba65-44c050702dbf.png)
