### PR TITLE
Enh/hide try metadata

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -56,6 +56,7 @@ export default class ApiRequest extends LitElement {
       fillRequestFieldsWithExample: { type: String, attribute: 'fill-request-fields-with-example' },
       useSummaryToListExamples: { type: String, attribute: 'use-summary-to-list-example' },
       allowTry: { type: String, attribute: 'allow-try' },
+      hideTryMetadata: { type: Boolean, attribute: 'hide-try-metadata' },
       renderStyle: { type: String, attribute: 'render-style' },
       schemaStyle: { type: String, attribute: 'schema-style' },
       activeSchemaTab: { type: String, attribute: 'active-schema-tab' },
@@ -1038,25 +1039,30 @@ export default class ApiRequest extends LitElement {
     return html`
     <div style="display:flex; align-items:flex-end; margin:16px 0; font-size:var(--font-size-small);">
       <div class="hide-in-small-screen" style="flex-direction:column; margin:0; width:calc(100% - 60px);">
-        <div style="display:flex; flex-direction:row; align-items:center; overflow:hidden;"> 
-          ${selectedServerHtml}
-        </div>
-        <div style="display:flex;">
-          <div style="font-weight:bold; padding-right:5px;">Authentication</div>
-          ${this.security?.length > 0
-            ? html`
-              ${this.api_keys.length > 0
-                ? html`<div style="color:var(--blue); overflow:hidden;"> 
-                    ${this.api_keys.length === 1
-                      ? `${this.api_keys[0]?.typeDisplay} in ${this.api_keys[0].in}`
-                      : `${this.api_keys.length} API keys applied`
-                    } 
-                  </div>`
-                : html`<div class="gray-text">Required  <span style="color:var(--red)">(None Applied)</span>`
-              }`
-            : html`<span class="gray-text"> Not Required </span>`
-          }
-        </div>
+        ${this.hideTryMetadata
+            ? null
+            : html`
+              <div style="display:flex; flex-direction:row; align-items:center; overflow:hidden;"> 
+                ${selectedServerHtml}
+              </div>
+              <div style="display:flex;">
+                <div style="font-weight:bold; padding-right:5px;">Authentication</div>
+                ${this.security?.length > 0
+                  ? html`
+                    ${this.api_keys.length > 0
+                      ? html`<div style="color:var(--blue); overflow:hidden;"> 
+                          ${this.api_keys.length === 1
+                            ? `${this.api_keys[0]?.typeDisplay} in ${this.api_keys[0].in}`
+                            : `${this.api_keys.length} API keys applied`
+                          } 
+                        </div>`
+                      : html`<div class="gray-text">Required  <span style="color:var(--red)">(None Applied)</span>`
+                    }`
+                  : html`<span class="gray-text"> Not Required </span>`
+                }
+              </div>
+            `
+        }
       </div>
       ${
         this.parameters.length > 0 || this.request_body

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -89,6 +89,7 @@ export default class RapiDoc extends LitElement {
       showInfo: { type: String, attribute: 'show-info' },
       allowAuthentication: { type: String, attribute: 'allow-authentication' },
       allowTry: { type: String, attribute: 'allow-try' },
+      hideTryMetadata: { type: Boolean, attribute: 'hide-try-metadata' },
       allowSpecUrlLoad: { type: String, attribute: 'allow-spec-url-load' },
       allowSpecFileLoad: { type: String, attribute: 'allow-spec-file-load' },
       allowSpecFileDownload: { type: String, attribute: 'allow-spec-file-download' },

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -66,6 +66,7 @@ export default class RapiDoc extends LitElement {
       useSummaryToListExamples: { type: String, attribute: 'use-summary-to-list-example' },
       persistAuth: { type: String, attribute: 'persist-auth' },
       onNavTagClick: { type: String, attribute: 'on-nav-tag-click' },
+      requestBodyRenderStyle: { type: String, attribute: 'request-body-render-style' }, // 'splitted' | 'default'
 
       // Schema Styles
       schemaStyle: { type: String, attribute: 'schema-style' },

--- a/src/templates/callback-template.js
+++ b/src/templates/callback-template.js
@@ -31,6 +31,7 @@ export default function callbackTemplate(callbacks) {
                       fill-request-fields-with-example = "${this.fillRequestFieldsWithExample}"
                       use-summary-to-list-example = "${this.useSummaryToListExamples}"
                       allow-try = "false"
+                      hide-try-metadata="${this.hideTryMetadata}"
                       render-style="${this.renderStyle}" 
                       schema-style = "${this.schemaStyle}"
                       request-body-render-style="${this.requestBodyRenderStyle}"

--- a/src/templates/callback-template.js
+++ b/src/templates/callback-template.js
@@ -33,6 +33,7 @@ export default function callbackTemplate(callbacks) {
                       allow-try = "false"
                       render-style="${this.renderStyle}" 
                       schema-style = "${this.schemaStyle}"
+                      request-body-render-style="${this.requestBodyRenderStyle}"
                       active-schema-tab = "${this.defaultSchemaTab}"
                       schema-expand-level = "${this.schemaExpandLevel}"
                       schema-description-expanded = "${this.schemaDescriptionExpanded}"

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -130,6 +130,7 @@ function endpointBodyTemplate(path) {
           fill-request-fields-with-example = "${this.fillRequestFieldsWithExample}"
           use-summary-to-list-example = "${this.useSummaryToListExamples}"
           allow-try = "${this.allowTry}"
+          hide-try-metadata="${this.hideTryMetadata}"
           accept = "${accept}"
           render-style="${this.renderStyle}" 
           schema-style = "${this.schemaStyle}" 

--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -133,6 +133,7 @@ function endpointBodyTemplate(path) {
           accept = "${accept}"
           render-style="${this.renderStyle}" 
           schema-style = "${this.schemaStyle}" 
+          request-body-render-style="${this.requestBodyRenderStyle}"
           schema-expand-level = "${this.schemaExpandLevel}"
           schema-description-expanded = "${this.schemaDescriptionExpanded}"
           allow-schema-description-expand-toggle = "${this.allowSchemaDescriptionExpandToggle}"

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -81,6 +81,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
         fill-request-fields-with-example = "${this.fillRequestFieldsWithExample}"
         use-summary-to-list-example = "${this.useSummaryToListExamples}"
         allow-try = "${this.allowTry}"
+        hide-try-metadata="${this.hideTryMetadata}"
         accept = "${accept}"
         render-style="${this.renderStyle}" 
         schema-style = "${this.schemaStyle}"

--- a/src/templates/expanded-endpoint-template.js
+++ b/src/templates/expanded-endpoint-template.js
@@ -84,6 +84,7 @@ export function expandedEndpointBodyTemplate(path, tagName = '') {
         accept = "${accept}"
         render-style="${this.renderStyle}" 
         schema-style = "${this.schemaStyle}"
+        request-body-render-style="${this.requestBodyRenderStyle}"
         active-schema-tab = "${this.defaultSchemaTab}"
         schema-expand-level = "${this.schemaExpandLevel}"
         schema-description-expanded = "${this.schemaDescriptionExpanded}"


### PR DESCRIPTION
This PR adds a new property `hideTryMetadata` in order to allow to hide the metadata on the try section:

![image](https://user-images.githubusercontent.com/92851105/162419501-e5152bfa-cbfc-4a82-81cc-229eaa9191cd.png)

So it can be like this:

![image](https://user-images.githubusercontent.com/92851105/162419537-39bebed4-7734-423c-a502-b44051a5dc01.png)
