### PR TITLE
Improve rendering of oneOf schema examples

### DIFF
--- a/docs/specs/oneof-combinations.yaml
+++ b/docs/specs/oneof-combinations.yaml
@@ -94,21 +94,21 @@ paths:
                         description: Null with a title
                         title: Null with a title
                       - type: 'null'
-                        description: Null without a title                            
+                        description: Null without a title
                   d:
                     type: string
-  /any-of-options-with-array-as-root:
+  /one-of-options-with-array-as-root:
     post:
-      summary: ANY-OF Options with Array as root
+      summary: ONE-OF Options with Array as root
       tags:
-        - ANY-OF Root as Array / Object
+        - ONE-OF Root as Array / Object
       requestBody:
-        description: ANY OF Option where root element is an array
+        description: ONE OF Option where root element is an array
         required: true
         content:
           application/json:
             schema:
-              anyOf:
+              oneOf:
                 - title: Option 1
                   type: array
                   items:
@@ -127,19 +127,19 @@ paths:
                         type: string
                       pin:
                         type: integer
-  
-  /any-of-options-with-object-as-root:
+
+  /one-of-options-with-object-as-root:
     post:
-      summary: ANY-OF Options with Object as root
+      summary: ONE-OF Options with Object as root
       tags:
-         - ANY-OF Root as Array / Object
+         - ONE-OF Root as Array / Object
       requestBody:
-        description: ANY OF Option where root element is an object
+        description: ONE OF Option where root element is an object
         required: true
         content:
           application/json:
             schema:
-              anyOf:
+              oneOf:
                 - title: Option 1
                   type: object
                   properties:

--- a/docs/specs/oneof.yaml
+++ b/docs/specs/oneof.yaml
@@ -49,6 +49,62 @@ paths:
                   prop2:
                     type: string
                     minLength: 10
+  /one-of/schema/senseless-options:
+    get:
+      tags:
+        - One Of Schema Model
+      summary: ONE-OF schema example generation test but with senseless options
+      operationId: empDetails
+      responses:
+        "200":
+          description: Should only generate examples for options that are objects
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: 'null'
+                  - type: string
+                  - type: object
+                    properties:
+                      option2_PropX:
+                        type: string
+                  - type: object
+                    properties:
+                      option1_PropA:
+                        type: string
+                      option1_PropB:
+                        type: string
+                properties:
+                  prop1:
+                    type: string
+                  prop2:
+                    type: string
+                    minLength: 10
+  /one-of/schema/root:
+    get:
+      tags:
+        - One Of Schema Model
+      summary: ONE-OF schema example generation with object and primitives at the root level (no common properties)
+      operationId: empDetails
+      responses:
+        "200":
+          description: Should generate examples for both the object and primitive options, but not for null
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: 'null'
+                  - type: string
+                  - type: object
+                    properties:
+                      option2_PropX:
+                        type: string
+                  - type: object
+                    properties:
+                      option1_PropA:
+                        type: string
+                      option1_PropB:
+                        type: string
 
 tags:
   - name: Employee Details

--- a/src/utils/schema-utils.js
+++ b/src/utils/schema-utils.js
@@ -383,19 +383,27 @@ export function schemaToSampleObj(schema, config = { }) {
         option2_PropX: 'string'
       }
       */
-      // let i = 0;
-      // Merge all examples of each oneOf-schema (pick only the first oneof schema, because it is one-of)
-      // for (const key in schema.oneOf) {
-      const firstOneOfSchema = schema.oneOf[0];
-      const oneOfSamples = schemaToSampleObj(firstOneOfSchema, config);
-      if (oneOfSamples instanceof Object) {
-        const oneOfSampleKeys = Object.keys(oneOfSamples);
-        // eslint-disable-next-line no-loop-func
-        oneOfSampleKeys.forEach((sampleKey, i) => {
-          const finalExample = oneOfSamples[sampleKey];
+      let i = 0;
+      // Merge all examples of each oneOf-schema
+      for (const key in schema.oneOf) {
+        const oneOfSamples = schemaToSampleObj(schema.oneOf[key], config);
+        for (const sampleKey in oneOfSamples) {
+          // 2. In the final example include a one-of item along with properties
+          let finalExample;
+          if (Object.keys(objWithSchemaProps).length > 0) {
+            if (oneOfSamples[sampleKey] === null || typeof oneOfSamples[sampleKey] !== 'object') {
+              // This doesn't really make sense since every oneOf schema _should_ be an object if there are common properties, so we'll skip this
+              continue;
+            } else {
+              finalExample = Object.assign(oneOfSamples[sampleKey], objWithSchemaProps);
+            }
+          } else {
+            finalExample = oneOfSamples[sampleKey];
+          }
           obj[`example-${i}`] = finalExample;
-          addSchemaInfoToExample(firstOneOfSchema, obj[`example-${i}`]);
-        });
+          addSchemaInfoToExample(schema.oneOf[key], obj[`example-${i}`]);
+          i++;
+        }
       }
     }
   } else if (schema.anyOf) {


### PR DESCRIPTION
### TL;DR: Render more example options for `oneOf` schemas again and fix initial issue of https://github.com/mrin9/RapiDoc/issues/620 and `null` type schemas breaking rendering of `response` schemas

### Explanation
In `9.2.0`, if a `oneOf` schema contains an option with a `"type": "null"`, then the `response` schema wouldn't be rendered, because the sample for it couldn't be merged with the (possible) common/general properties. This was broken since the code adding those common properties was added (df594fb), in release `9.1.0`.

It has been fixed in fc49949, but not correctly. The sample for `null` would render as `"foo": { }` instead of `"foo": null`, but at least the response was rendering again (which is the issue I was experiencing too).

I already wrote a fix targeting `9.2.0`, but then I saw that, as a fix for https://github.com/mrin9/RapiDoc/issues/620, which was addressing the issue that a `string` type schema was being exploded with a property for each character of the string, the whole multi-sample rendering code was discarded to "solve" the issue.

So, I adjusted my fix to solve that string-explosion issue too.

The actual issue is that for a `string` type schema, it doesn't make sense to have common `properties` defined, so trying to add the common properties to the sample just shouldn't be done.

### Solution
I've re-added the code from `9.2.0`, which renders multiple samples and fixed that. 
I wrote the initial code able to render multiple samples 18 months ago, so I wanted to fix the addition which added the common `properties`, and have multiple samples again.

The difference is quite simple: 
1. only add the common `properties` when there are any
2. if there are common `properties`, discard any sample from a non-object schema, as such `oneOf` (sub)schema doesn't make sense anyhow
3. if there aren't any common `properties`, then we can just use the sample directly

### Examples
- I added  an example to show that senseless `oneOf` schemas are ignored (common `properties` combined with `null`, or another non-object schema): https://sneakyvv.github.io/RapiDoc/examples/oneof.html#get-/one-of/schema/senseless-options
- That one also includes an example to showcase rendering of `non-object` type schemas (at root, `null` type is ignored): https://sneakyvv.github.io/RapiDoc/examples/oneof.html#get-/one-of/schema/root
- There was already an example showcasing all kind of types of schemas as a property of an object: https://sneakyvv.github.io/RapiDoc/examples/oneof-combinations.html#get-/one-of-primitives-and-object
- Rewrote the fix for #620, the existing example works with multiple samples now: https://sneakyvv.github.io/RapiDoc/examples/oneof-with-refs.html