### PR TITLE
Small quality of life fixes

### DIFF
--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -401,7 +401,7 @@ export default function securitySchemeTemplate() {
           <div class="blue-text"> ${providedApiKeys.length} API key applied </div>
           <div style="flex:1"></div>
           <button class="m-btn thin-border" part="btn btn-outline" @click=${() => { onClearAllApiKeys.call(this); }}>CLEAR ALL API KEYS</button>`
-        : html`<div class="red-text">No API key applied</div>`
+        : html`<div class="red-text">No API key applied - <a href="#auth">Apply one here</a></div>`
       }
     </div>
     ${this.resolvedSpec.securitySchemes && this.resolvedSpec.securitySchemes.length > 0
@@ -411,7 +411,8 @@ export default function securitySchemeTemplate() {
             <tr id="security-scheme-${v.securitySchemeId}" class="${v.type.toLowerCase()}">
               <td style="max-width:500px; overflow-wrap: break-word;">
                 <div style="line-height:28px; margin-bottom:5px;">
-                  <span style="font-weight:bold; font-size:var(--font-size-regular)">${v.typeDisplay}</span>
+                  <span style="font-weight:bold; font-size:var(--font-size-regular)">${this.resolvedSpec.securitySchemes.filter((secScheme) => secScheme.typeDisplay === v.typeDisplay).length > 1 ? `- 
+                  ${v.securitySchemeId}` : null}</span>
                   ${v.finalKeyValue
                     ? html`
                       <span class='blue-text'>  ${v.finalKeyValue ? 'Key Applied' : ''} </span>
@@ -433,13 +434,13 @@ export default function securitySchemeTemplate() {
                     <div style="margin-bottom:5px">
                       ${v.type.toLowerCase() === 'apikey'
                         ? html`Send <code>${v.name}</code> in <code>${v.in}</code>`
-                        : html`Send <code>Authorization</code> in <code>header</code> containing the word <code>Bearer</code> followed by a space and a Token String.`
+                        : html`Send <code>Authorization</code> in <code>header</code> containing the word <code>Bearer</code> followed by a space and the ${e.bearerFormat ?? "Token String"}.`
                       }
                     </div>
                     <div style="max-height:28px;">
                       ${v.in !== 'cookie'
                         ? html`
-                          <input type = "text" value = "${v.value}" class="${v.type} ${v.securitySchemeId} api-key-input" placeholder = "api-token" spellcheck = "false">
+                          <input type = "text" value = "${v.value}" class="${v.type} ${v.securitySchemeId} api-key-input" placeholder = "${e.bearerFormat ?? "api-token"}" spellcheck = "false"> 
                           <button class="m-btn thin-border" style = "margin-left:5px;"
                             part = "btn btn-outline"
                             @click="${(e) => { onApiKeyChange.call(this, v.securitySchemeId, e); }}">


### PR DESCRIPTION
This PR:
- ✔️ Adds a link to the `#auth` anchor on the "no api key set" message, so that readers get a CTA how to fix it.
  **After**: (I don't have a non-edited version to screenshot for a Before)
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/900cd3a5-5ceb-49f3-b274-e523c200fa7d)

- ✔️ Renders the `bearerFormat` string as the field hint text, for HTTP Bearer type auth, if one is set. (If not set, uses the original `api-token`.)
  **Before**:
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/e89f5690-c835-4b30-a3b6-0d1607ef4dcc)
  **After**:
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/3c95d600-c20c-4010-b362-2090a9a593fd)

- ✔️ Similarly, renders the `bearerFormat` string as the noun in the instructional text, if set. (If not set, uses the original "Token String".)
  **Before**:
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/966dba04-2bcc-4d95-9824-cc1276c0d4c0)
  **After**:
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/51a2d0eb-0398-4de2-a52c-bef6aa4e5e16)

- ⚠️ Attempts to check if there are >1 of a type of security scheme, and add the `${v.securitySchemeId}` if there are, except I couldn't get this working or troubleshoot effectively with my rudimentary JS skills.
  Not working right now, but when it's done it would look something like this:
  **Before**: two different auth formats with the same name, so you have to use the descriptive text to tell them apart.
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/f925c528-01d7-4831-b7c4-d310d456b971)
  **After**: much easier to see that these are different
  ![image](https://github.com/rapi-doc/RapiDoc/assets/17016388/fa929ceb-65bf-48b0-8a39-bc1be1f02cc0)

Thanks all!