### PR TITLE
fix/improve deduplication of header values

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1937,9 +1937,21 @@ ${responseContent}</pre
     curl = `curl -X ${this.method.toUpperCase()} "${curlUrl}" \\\n`;
 
     fetchHeaders.forEach((value, key) => {
-      let tempHeaderArray = value.split(',');
-      tempHeaderArray = tempHeaderArray.map((el) => el.trim()).filter((string, index) => tempHeaderArray.indexOf(string) === index);
-      fetchHeaders.set(key, tempHeaderArray.join(', '));
+      const seenValues = [];
+      const newValue = value
+        .split(',')
+        .map((val) => {
+          const normalizedValue = val.trim().toLowerCase();
+          if (seenValues.includes(normalizedValue)) {
+            return null;
+          } else {
+            seenValues.push(normalizedValue);
+            return val;
+          }
+        })
+        .filter((val) => val !== null)
+        .join(',');
+      fetchHeaders.set(key, newValue);
     });
 
     curlHeaders = Array.from(fetchHeaders)


### PR DESCRIPTION
Fixes the header deduplication for curl requests introduced in #1024

When the old code receives the following input:
`"hello, world, some, cool, World, words, IN, a,ROW,TesT,Hello,testing"` 
as the header value, it deduplicates the it to
`hello, ROW, TesT, Hello, testing`

Which has 3 problems:
1. the header values are not deduplicated correctly, resulting in the fact that non-duplicate elements are removed as well
2. the spacing around the comma is not presevered and every element is exactly one space apart after deduplicating
3. duplicate elements with different casing are left in the resulting header value

When the new code receives the same input, it deduplicates them correctly, while fixing the other 2 mentioned issues as well:
`hello, world, some, cool, words, IN, a,ROW,TesT,testing`

Closes #1063 