### PR TITLE
feat: allow ctrl+click enum array values to add/remove

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -527,7 +527,13 @@ export default class ApiRequest extends LitElement {
                         const inputEl = e.target.closest('table').querySelector(`[data-pname="${param.name}"]`);
                         if (inputEl) {
                           if (e.target.dataset.type === 'array') {
-                            inputEl.value = [e.target.dataset.enum];
+                            if (e.ctrlKey) {
+                              inputEl.value = !Array.isArray(inputEl.value) ? [e.target.dataset.enum]
+                                : inputEl.value.includes(e.target.dataset.enum) ? inputEl.value.filter((val) => val !== e.target.dataset.enum)
+                                : [...inputEl.value, e.target.dataset.enum];
+                            } else {
+                                inputEl.value = [e.target.dataset.enum];
+                            }
                           } else {
                             inputEl.value = e.target.dataset.enum;
                           }


### PR DESCRIPTION
Quick and dirty feature-add allowing quickly toggling enum values in and out of an array field.

https://github.com/user-attachments/assets/7a6c434d-8d71-418a-a134-e74b86d254c4

May explore a variant that has no layout shift in the future, because the current reflow is a bit awkward imo.