### PR TITLE
Fix typo

### DIFF
--- a/docs/css-parts.html
+++ b/docs/css-parts.html
@@ -139,7 +139,7 @@
     </div>
     <span>
       Below code snippet uses <span class="mono bold blue"> rapi-doc::part(nav-bar)</span> 
-      selector to target the navigation bar and renders a gardient navigation bar | &nbsp;
+      selector to target the navigation bar and renders a gradient navigation bar | &nbsp;
       <a href="./examples-theme/cssparts-nav1.html" target="_blank"> 
         Demo</a>
     </span>


### PR DESCRIPTION
Corrects a minor typo in the documentation by fixing the spelling of "gradient" in the CSS Parts section.