### PR TITLE
Fix default scrollTo in Focused mode

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -840,9 +840,11 @@ export default class RapiDoc extends LitElement {
    * From the URL return the ID of the element whether it is in the hash or if used a router prefix without a hash
    */
   getElementIDFromURL() {
-    const baseURL = this.getComponentBaseURL();
-    const elementId = window.location.href.replace(baseURL + this.routePrefix, '');
-    return elementId;
+    const baseURLWithPrefix = this.getComponentBaseURL() + this.routePrefix;
+    if (window.location.href.startsWith(baseURLWithPrefix)) {
+      return window.location.href.replace(baseURLWithPrefix, '');
+    }
+    return undefined;
   }
 
   replaceHistoryState(hashId) {


### PR DESCRIPTION
I noticed a regression when upgrading from 9.3.2, in focused mode previously the page would default scroll to the `Overview` when no `#` route is provided.

The getElementId changes for #852 meant that when no route is provided, the entire url would be returned, where previously an empty/undefined value would be used and hit: https://github.com/rapi-doc/RapiDoc/blob/7f53d25959e5a4e1beb4b610aaef445b896838f2/src/rapidoc.js#L808-L814 - which doesn't happen if the url is returned.