### PR TITLE
Fix specificity of nav-bar-tag color

### DIFF
--- a/src/styles/nav-styles.js
+++ b/src/styles/nav-styles.js
@@ -104,7 +104,7 @@ export default css`
   background-color: var(--nav-hover-bg-color);
 }
 
-.nav-bar-tag {
+.nav-bar .nav-bar-tag {
   font-size: var(--font-size-regular);
   color: var(--nav-accent-color);
   border-left:4px solid transparent;


### PR DESCRIPTION
Upgrading from 9.3.2 I saw a regression in the nav-bar headers in focused mode. The `nav-text-color` is overriding the `nav-accent-color`.