### PR TITLE
Fix #1076 Field Descriptions missing via Components Section

### DIFF
--- a/src/templates/components-template.js
+++ b/src/templates/components-template.js
@@ -21,6 +21,7 @@ function schemaBodyTemplate(sComponent) {
         schema-hide-read-only = "false"
         schema-hide-write-only = "${this.schemaHideWriteOnly}"
         exportparts = "schema-description:schema-description, schema-multiline-toggle:schema-multiline-toggle"
+        style="display:block;"
       > </schema-table>`
     : html`
       <schema-tree
@@ -31,6 +32,7 @@ function schemaBodyTemplate(sComponent) {
         schema-hide-read-only = "false"
         schema-hide-write-only = "${this.schemaHideWriteOnly}"
         exportparts = "schema-description:schema-description, schema-multiline-toggle:schema-multiline-toggle"
+        style="display:block;"
       > </schema-tree>`
 }
   </div>`;


### PR DESCRIPTION
Adding a display block makes the descriptions appear in the components section again.

Note: The css display property was set to block (explicitly or implicitly) for all the other usages of the schema-table component, but not for this one.