### PR TITLE
feat: add 'part' attribute to element of the nav paths group

### DIFF
--- a/src/templates/navbar-template.js
+++ b/src/templates/navbar-template.js
@@ -205,7 +205,11 @@ export default function navbarTemplate() {
                 }`
               : ''
             }
-            <div class='nav-bar-paths-under-tag' style='max-height:${(tag.expanded || this.renderStyle === 'read') ? ((tag.paths?.length || 1) * 50) : 0}px;'>
+            <div 
+              class='nav-bar-paths-under-tag'
+              part='section-navbar-item-paths-under-tag'
+              style='max-height:${(tag.expanded || this.renderStyle === 'read') ? ((tag.paths?.length || 1) * 50) : 0}px;'
+            >
               <!-- Paths in each tag (endpoints) -->
               ${tag.paths.filter((v) => {
                 if (this.searchVal) {


### PR DESCRIPTION
Reason: Add ability to override max-height style via CSS on this element, because 50px of height per path item is not enough in some cases