### PR TITLE
Remove unnecessary style from pre element

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1084,7 +1084,7 @@ export default class ApiRequest extends LitElement {
           : html`
             <div part="tab-content" class="tab-content col m-markdown" style="flex:1; display:${this.activeResponseTab === 'response' ? 'flex' : 'none'};" >
               <button class="toolbar-btn" style="position:absolute; top:12px; right:8px" @click='${(e) => { copyToClipboard(this.responseText, e); }}' part="btn btn-fill"> Copy </button>
-              <pre style="white-space:pre; min-height:50px; height:var(--resp-area-height, 400px); resize:vertical; overflow:auto">${responseContent}</pre>
+              <pre style="min-height:50px; height:var(--resp-area-height, 400px); resize:vertical; overflow:auto">${responseContent}</pre>
             </div>`
         }
         <div part="tab-content" class="tab-content col m-markdown" style="flex:1; display:${this.activeResponseTab === 'headers' ? 'flex' : 'none'};" >


### PR DESCRIPTION
Hard coding "white-space:pre;" in the parent element of the results tab-content means long strings like tokens will always exceed the parent box element and force a horizonal scroll bar. This is particularly annoying when you need to copy and use the tokens in other places. It also makes it nearly impossible to use <style> or css changes to turn word wrapping on because the hard coded "white-space:pre;" overwrites everything. Lastly this is the ONLY place where this style is hard coded.